### PR TITLE
insert takes 2 arguments

### DIFF
--- a/pysle/isletool.py
+++ b/pysle/isletool.py
@@ -312,8 +312,8 @@ def _parsePronunciation(pronunciationStr):
                 stressedPhoneList.insert(0, j)
                 break
             elif u'ˌ' in phone:
-                stressedSyllableList.insert(i)
-                stressedPhoneList.insert(j)
+                stressedSyllableList.append(i)
+                stressedPhoneList.append(j)
     
     return syllableList, stressedSyllableList, stressedPhoneList
             


### PR DESCRIPTION
In python 3.4 and 2.7 I get an error  "insert takes 2 arguments". This PR fixes it, but I had to assume it was intended to be an append.