### PR TITLE
Praattool syllabification fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.8"
   - "3.9"
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+
+# Pysle Changelog
+
+*Pysle uses semantic versioning (Major.Minor.Patch)*
+
+Ver 3.0 (Oct 30, 2021)
+- dropping support for python 2.7
+- some important bugfixes related to syllabification estimation
+
+Ver 2.3 (Nov 18, 2020)
+- add exactMatch to isletool.search()
+    - when True, will return exact phonetic matches, ignoring stress, syllable, and word markers
+    - see examples/dictionary_search.py
+
+Ver 2.2 (Nov 17, 2020)
+- the ISLEdict is now bundled with pysle--no need to download it separately!
+- loading the isleDict is ~10% faster
+
+Ver 2.1 (May 31, 2020)
+- add transcribe function, given a word or series of words, get a possible pronunciation;
+    - see examples/isletool_examples.py
+
+Ver 2.0 (May 27, 2020)
+- cleaned up the api a little, including some functions that weren't usable
+- updated documentation and readme files.  Added pdoc documentation
+
+Ver 1.5 (March 3, 2017)
+- substantial bugfixes made, particularly to the syllable-marking code
+
+Ver 1.4 (July 9, 2016)
+- added search functionality
+- ported code to use the new unicode IPA-based isledict
+    - (the old one was ascii)
+- (Oct 20, 2016) Integration tests added; using Travis CI and Coveralls
+    - for build automation.  No new functionality added.
+
+Ver 1.3 (March 15, 2016)
+- added indicies for stressed vowels
+
+Ver 1.2 (June 20, 2015)
+- Python 3.x support
+
+Ver 1.1 (January 30, 2015)
+- word lookup ~65 times faster
+
+Ver 1.0 (October 23, 2014)
+- first public release.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Please view [CHANGELOG.md](https://github.com/timmahrt/pysle/blob/main/CHANGELOG
   for normal use.
 
 
-## Optional resources
+## ISLE Dictionary
 
 
 pysle requires the ISLEdict pronunciation dictionary

--- a/README.md
+++ b/README.md
@@ -117,8 +117,6 @@ Ver 1.0 (October 23, 2014)
 
 ## Requirements
 
-- ``Python 2.7.*`` or above
-
 - ``Python 3.7.*`` or above (or below, probably)
 
 [Click here to visit travis-ci and see the specific versions of python that pysle is currently tested under](<https://travis-ci.org/timmahrt/pysle>)

--- a/README.md
+++ b/README.md
@@ -75,44 +75,7 @@ What can you do with this library?
 
 *Pysle uses semantic versioning (Major.Minor.Patch)*
 
-Ver 2.3 (Nov 18, 2020)
-- add exactMatch to isletool.search()
-    - when True, will return exact phonetic matches, ignoring stress, syllable, and word markers
-    - see examples/dictionary_search.py
-
-Ver 2.2 (Nov 17, 2020)
-- the ISLEdict is now bundled with pysle--no need to download it separately!
-- loading the isleDict is ~10% faster
-
-Ver 2.1 (May 31, 2020)
-- add transcribe function, given a word or series of words, get a possible pronunciation;
-    - see examples/isletool_examples.py
-
-Ver 2.0 (May 27, 2020)
-- cleaned up the api a little, including some functions that weren't usable
-- updated documentation and readme files.  Added pdoc documentation
-
-Ver 1.5 (March 3, 2017)
-- substantial bugfixes made, particularly to the syllable-marking code
-
-Ver 1.4 (July 9, 2016)
-- added search functionality
-- ported code to use the new unicode IPA-based isledict
-    - (the old one was ascii)
-- (Oct 20, 2016) Integration tests added; using Travis CI and Coveralls
-    - for build automation.  No new functionality added.
-
-Ver 1.3 (March 15, 2016)
-- added indicies for stressed vowels
-
-Ver 1.2 (June 20, 2015)
-- Python 3.x support
-
-Ver 1.1 (January 30, 2015)
-- word lookup ~65 times faster
-
-Ver 1.0 (October 23, 2014)
-- first public release.
+Please view [CHANGELOG.md](https://github.com/timmahrt/pysle/blob/main/CHANGELOG.md) for version history.
 
 
 ## Requirements

--- a/docs/pysle/praattools.html
+++ b/docs/pysle/praattools.html
@@ -48,6 +48,15 @@
             <li>
                     <a class="function" href="#syllabifyTextgrid">syllabifyTextgrid</a>
             </li>
+            <li>
+                    <a class="class" href="#StressedSyllableDetectionError">StressedSyllableDetectionError</a>
+                            <ul class="memberlist">
+                        <li>
+                                <a class="function" href="#StressedSyllableDetectionError.__init__">StressedSyllableDetectionError</a>
+                        </li>
+                </ul>
+
+            </li>
     </ul>
 
 
@@ -93,7 +102,7 @@
 
 
 <span class="k">try</span><span class="p">:</span>
-    <span class="kn">from</span> <span class="nn">praatio</span> <span class="kn">import</span> <span class="n">tgio</span>
+    <span class="kn">from</span> <span class="nn">praatio</span> <span class="kn">import</span> <span class="n">textgrid</span>
     <span class="kn">from</span> <span class="nn">praatio</span> <span class="kn">import</span> <span class="n">praatio_scripts</span>
 <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
     <span class="k">raise</span> <span class="n">OptionalFeatureError</span><span class="p">()</span>
@@ -202,10 +211,10 @@
         <span class="n">phoneEntryList</span><span class="o">.</span><span class="n">extend</span><span class="p">(</span><span class="n">subPhoneEntryList</span><span class="p">)</span>
 
     <span class="c1"># Replace or add the word tier</span>
-    <span class="n">newWordTier</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="n">wordTierName</span><span class="p">,</span>
-                                    <span class="n">wordEntryList</span><span class="p">,</span>
-                                    <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span>
-                                    <span class="n">tg</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">)</span>
+    <span class="n">newWordTier</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="n">wordTierName</span><span class="p">,</span>
+                                        <span class="n">wordEntryList</span><span class="p">,</span>
+                                        <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span>
+                                        <span class="n">tg</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">)</span>
     <span class="k">if</span> <span class="n">wordTier</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
         <span class="n">tg</span><span class="o">.</span><span class="n">replaceTier</span><span class="p">(</span><span class="n">wordTierName</span><span class="p">,</span> <span class="n">newWordTier</span><span class="p">)</span>
     <span class="k">else</span><span class="p">:</span>
@@ -215,10 +224,10 @@
     <span class="c1"># Add the phone tier</span>
     <span class="c1"># This is mainly used as an annotation tier</span>
     <span class="k">if</span> <span class="n">phoneHelperTierName</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="ow">and</span> <span class="nb">len</span><span class="p">(</span><span class="n">phoneEntryList</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
-        <span class="n">newPhoneTier</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="n">phoneHelperTierName</span><span class="p">,</span>
-                                         <span class="n">phoneEntryList</span><span class="p">,</span>
-                                         <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span>
-                                         <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">)</span>
+        <span class="n">newPhoneTier</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="n">phoneHelperTierName</span><span class="p">,</span>
+                                             <span class="n">phoneEntryList</span><span class="p">,</span>
+                                             <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span>
+                                             <span class="n">tg</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">)</span>
         <span class="k">if</span> <span class="n">phoneHelperTierName</span> <span class="ow">in</span> <span class="n">tg</span><span class="o">.</span><span class="n">tierNameList</span><span class="p">:</span>
             <span class="n">tg</span><span class="o">.</span><span class="n">replaceTier</span><span class="p">(</span><span class="n">phoneHelperTierName</span><span class="p">,</span> <span class="n">newPhoneTier</span><span class="p">)</span>
         <span class="k">else</span><span class="p">:</span>
@@ -287,10 +296,10 @@
         <span class="n">phoneEntryList</span><span class="o">.</span><span class="n">extend</span><span class="p">(</span><span class="n">subPhoneEntryList</span><span class="p">)</span>
 
     <span class="c1"># Replace or add the phone tier</span>
-    <span class="n">newPhoneTier</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="n">phoneTierName</span><span class="p">,</span>
-                                     <span class="n">phoneEntryList</span><span class="p">,</span>
-                                     <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span>
-                                     <span class="n">tg</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">)</span>
+    <span class="n">newPhoneTier</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="n">phoneTierName</span><span class="p">,</span>
+                                        <span class="n">phoneEntryList</span><span class="p">,</span>
+                                        <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span>
+                                        <span class="n">tg</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">)</span>
     <span class="k">if</span> <span class="n">phoneTier</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
         <span class="n">tg</span><span class="o">.</span><span class="n">replaceTier</span><span class="p">(</span><span class="n">phoneTierName</span><span class="p">,</span> <span class="n">newPhoneTier</span><span class="p">)</span>
     <span class="k">else</span><span class="p">:</span>
@@ -301,7 +310,9 @@
 
 
 <span class="k">def</span> <span class="nf">syllabifyTextgrid</span><span class="p">(</span><span class="n">isleDict</span><span class="p">,</span> <span class="n">tg</span><span class="p">,</span> <span class="n">wordTierName</span><span class="p">,</span> <span class="n">phoneTierName</span><span class="p">,</span>
-                      <span class="n">skipLabelList</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">startT</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">stopT</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
+                      <span class="n">skipLabelList</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">startT</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">stopT</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+                      <span class="n">stressedSyllableDetectionErrors</span><span class="o">=</span><span class="s2">&quot;ERROR&quot;</span><span class="p">,</span>
+                      <span class="n">syllabificationError</span><span class="o">=</span><span class="s2">&quot;ERROR&quot;</span><span class="p">):</span>
     <span class="sd">&#39;&#39;&#39;</span>
 <span class="sd">    Given a textgrid, syllabifies the phones in the textgrid</span>
 
@@ -313,6 +324,12 @@
 <span class="sd">    Returns a textgrid with only two tiers containing syllable information</span>
 <span class="sd">    (syllabification of the phone tier and a tier marking word-stress).</span>
 <span class="sd">    &#39;&#39;&#39;</span>
+
+    <span class="k">if</span> <span class="n">stressedSyllableDetectionErrors</span> <span class="ow">not</span> <span class="ow">in</span> <span class="p">[</span><span class="s2">&quot;IGNORE&quot;</span><span class="p">,</span> <span class="s2">&quot;WARN&quot;</span><span class="p">,</span> <span class="s2">&quot;ERROR&quot;</span><span class="p">]:</span>
+        <span class="k">raise</span> <span class="s2">&quot;Function argument &#39;stressedSyllableDetectionErrors&#39; must be one of &#39;IGNORE&#39;, &#39;WARN&#39;, or &#39;ERROR&#39;&quot;</span>
+    <span class="k">if</span> <span class="n">syllabificationError</span> <span class="ow">not</span> <span class="ow">in</span> <span class="p">[</span><span class="s2">&quot;IGNORE&quot;</span><span class="p">,</span> <span class="s2">&quot;WARN&quot;</span><span class="p">,</span> <span class="s2">&quot;ERROR&quot;</span><span class="p">]:</span>
+        <span class="k">raise</span> <span class="s2">&quot;Function argument &#39;syllabificationError&#39; must be one of &#39;IGNORE&#39;, &#39;WARN&#39;, or &#39;ERROR&#39;&quot;</span>
+
     <span class="n">minT</span> <span class="o">=</span> <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span>
     <span class="n">maxT</span> <span class="o">=</span> <span class="n">tg</span><span class="o">.</span><span class="n">maxTimestamp</span>
 
@@ -349,19 +366,27 @@
             <span class="n">sylTmp</span> <span class="o">=</span> <span class="n">pronunciationtools</span><span class="o">.</span><span class="n">findBestSyllabification</span><span class="p">(</span><span class="n">isleDict</span><span class="p">,</span>
                                                                 <span class="n">word</span><span class="p">,</span>
                                                                 <span class="n">phoneList</span><span class="p">)</span>
+
         <span class="k">except</span> <span class="n">isletool</span><span class="o">.</span><span class="n">WordNotInISLE</span><span class="p">:</span>
-            <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Word (&#39;</span><span class="si">%s</span><span class="s2">&#39;) not is isle -- skipping syllabification&quot;</span> <span class="o">%</span> <span class="n">word</span><span class="p">)</span>
+            <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Not is isle -- skipping syllabification; Word &#39;</span><span class="si">{</span><span class="n">word</span><span class="si">}</span><span class="s2">&#39; at </span><span class="si">{</span><span class="n">start</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
             <span class="k">continue</span>
         <span class="k">except</span> <span class="n">pronunciationtools</span><span class="o">.</span><span class="n">NullPronunciationError</span><span class="p">:</span>
-            <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Word (&#39;</span><span class="si">%s</span><span class="s2">&#39;) has no provided pronunciation&quot;</span> <span class="o">%</span> <span class="n">word</span><span class="p">)</span>
+            <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;No provided pronunciation; Word &#39;</span><span class="si">{</span><span class="n">word</span><span class="si">}</span><span class="s2">&#39; at </span><span class="si">{</span><span class="n">start</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
             <span class="k">continue</span>
-        <span class="k">except</span> <span class="ne">AssertionError</span><span class="p">:</span>
-            <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Unable to syllabify &#39;</span><span class="si">%s</span><span class="s2">&#39;&quot;</span> <span class="o">%</span> <span class="n">word</span><span class="p">)</span>
-            <span class="k">continue</span>
+        <span class="k">except</span> <span class="n">pronunciationtools</span><span class="o">.</span><span class="n">ImpossibleSyllabificationError</span> <span class="k">as</span> <span class="n">e</span><span class="p">:</span>
+            <span class="k">if</span> <span class="n">syllabificationError</span> <span class="o">==</span> <span class="s1">&#39;SKIP&#39;</span><span class="p">:</span>
+                <span class="k">continue</span>
+
+            <span class="k">if</span> <span class="n">syllabificationError</span> <span class="o">==</span> <span class="s1">&#39;WARN&#39;</span><span class="p">:</span>
+                <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Syllabification error; Word &#39;</span><span class="si">{</span><span class="n">word</span><span class="si">}</span><span class="s2">&#39; at </span><span class="si">{</span><span class="n">start</span><span class="si">}</span><span class="s2">; &quot;</span> <span class="o">+</span> <span class="nb">str</span><span class="p">(</span><span class="n">e</span><span class="p">))</span>
+                <span class="k">continue</span>
+
+            <span class="k">raise</span>
 
         <span class="n">stressI</span> <span class="o">=</span> <span class="n">sylTmp</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
         <span class="n">stressJ</span> <span class="o">=</span> <span class="n">sylTmp</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span>
         <span class="n">syllableList</span> <span class="o">=</span> <span class="n">sylTmp</span><span class="p">[</span><span class="mi">2</span><span class="p">]</span>
+        <span class="n">islesAdjustedSyllableList</span> <span class="o">=</span> <span class="n">sylTmp</span><span class="p">[</span><span class="mi">3</span><span class="p">]</span>
 
         <span class="k">if</span> <span class="n">stressI</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="ow">and</span> <span class="n">stressJ</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
             <span class="n">syllableList</span><span class="p">[</span><span class="n">stressI</span><span class="p">][</span><span class="n">stressJ</span><span class="p">]</span> <span class="o">+=</span> <span class="sa">u</span><span class="s2">&quot;ˈ&quot;</span>
@@ -394,36 +419,67 @@
                                                    <span class="n">syllableEnd</span><span class="p">,</span>
                                                    <span class="s2">&quot;strict&quot;</span><span class="p">,</span> <span class="kc">False</span><span class="p">)</span>
 
-                <span class="n">phoneList</span> <span class="o">=</span> <span class="p">[</span><span class="n">entry</span> <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">syllablePhoneTier</span><span class="o">.</span><span class="n">entryList</span>
+                <span class="n">syllablePhoneList</span> <span class="o">=</span> <span class="p">[</span><span class="n">entry</span> <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">syllablePhoneTier</span><span class="o">.</span><span class="n">entryList</span>
                              <span class="k">if</span> <span class="n">entry</span><span class="p">[</span><span class="mi">2</span><span class="p">]</span> <span class="o">!=</span> <span class="s1">&#39;&#39;</span><span class="p">]</span>
-                <span class="n">justPhones</span> <span class="o">=</span> <span class="p">[</span><span class="n">phone</span> <span class="k">for</span> <span class="n">_</span><span class="p">,</span> <span class="n">_</span><span class="p">,</span> <span class="n">phone</span> <span class="ow">in</span> <span class="n">phoneList</span><span class="p">]</span>
+                <span class="n">justPhones</span> <span class="o">=</span> <span class="p">[</span><span class="n">phone</span> <span class="k">for</span> <span class="n">_</span><span class="p">,</span> <span class="n">_</span><span class="p">,</span> <span class="n">phone</span> <span class="ow">in</span> <span class="n">syllablePhoneList</span><span class="p">]</span>
                 <span class="n">cvList</span> <span class="o">=</span> <span class="n">pronunciationtools</span><span class="o">.</span><span class="n">simplifyPronunciation</span><span class="p">(</span><span class="n">justPhones</span><span class="p">)</span>
 
+                <span class="n">tmpStressJ</span> <span class="o">=</span> <span class="kc">None</span>
                 <span class="k">try</span><span class="p">:</span>
                     <span class="n">tmpStressJ</span> <span class="o">=</span> <span class="n">cvList</span><span class="o">.</span><span class="n">index</span><span class="p">(</span><span class="s1">&#39;V&#39;</span><span class="p">)</span>
                 <span class="k">except</span> <span class="ne">ValueError</span><span class="p">:</span>
-                    <span class="k">for</span> <span class="n">char</span> <span class="ow">in</span> <span class="p">[</span><span class="sa">u</span><span class="s1">&#39;r&#39;</span><span class="p">,</span> <span class="sa">u</span><span class="s1">&#39;n&#39;</span><span class="p">,</span> <span class="sa">u</span><span class="s1">&#39;l&#39;</span><span class="p">]:</span>
+                    <span class="k">for</span> <span class="n">char</span> <span class="ow">in</span> <span class="p">[</span><span class="sa">u</span><span class="s1">&#39;r&#39;</span><span class="p">,</span> <span class="sa">u</span><span class="s1">&#39;m&#39;</span><span class="p">,</span> <span class="sa">u</span><span class="s1">&#39;n&#39;</span><span class="p">,</span> <span class="sa">u</span><span class="s1">&#39;l&#39;</span><span class="p">]:</span>
                         <span class="k">if</span> <span class="n">char</span> <span class="ow">in</span> <span class="n">cvList</span><span class="p">:</span>
                             <span class="n">tmpStressJ</span> <span class="o">=</span> <span class="n">cvList</span><span class="o">.</span><span class="n">index</span><span class="p">(</span><span class="n">char</span><span class="p">)</span>
                             <span class="k">break</span>
 
-                <span class="n">phoneStart</span><span class="p">,</span> <span class="n">phoneEnd</span> <span class="o">=</span> <span class="n">phoneList</span><span class="p">[</span><span class="n">tmpStressJ</span><span class="p">][:</span><span class="mi">2</span><span class="p">]</span>
+                <span class="k">if</span> <span class="n">tmpStressJ</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+                    <span class="k">if</span> <span class="n">stressedSyllableDetectionErrors</span> <span class="o">==</span> <span class="s1">&#39;SKIP&#39;</span><span class="p">:</span>
+                        <span class="k">continue</span>
+
+                    <span class="k">if</span> <span class="n">stressedSyllableDetectionErrors</span> <span class="o">==</span> <span class="s1">&#39;WARN&#39;</span><span class="p">:</span>
+                        <span class="nb">print</span> <span class="p">(</span><span class="sa">f</span><span class="s2">&quot;No stressed syllable; word: &#39;</span><span class="si">{</span><span class="n">word</span><span class="si">}</span><span class="s2">&#39;, actual mapped pronunciation: </span><span class="si">{</span><span class="n">syllableList</span><span class="si">}</span><span class="s2">, ISLE&#39;s mapped pronunciation: </span><span class="si">{</span><span class="n">islesAdjustedSyllableList</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
+                        <span class="k">continue</span>
+
+                    <span class="k">raise</span><span class="p">(</span><span class="n">StressedSyllableDetectionError</span><span class="p">(</span><span class="n">word</span><span class="p">,</span> <span class="n">phoneList</span><span class="p">,</span> <span class="n">syllableList</span><span class="p">,</span> <span class="n">islesAdjustedSyllableList</span><span class="p">))</span>
+
+                <span class="n">phoneStart</span><span class="p">,</span> <span class="n">phoneEnd</span> <span class="o">=</span> <span class="n">syllablePhoneList</span><span class="p">[</span><span class="n">tmpStressJ</span><span class="p">][:</span><span class="mi">2</span><span class="p">]</span>
                 <span class="n">tonicPEntryList</span><span class="o">.</span><span class="n">append</span><span class="p">((</span><span class="n">phoneStart</span><span class="p">,</span> <span class="n">phoneEnd</span><span class="p">,</span> <span class="s1">&#39;T&#39;</span><span class="p">))</span>
 
     <span class="c1"># Create a textgrid with the two syllable-level tiers</span>
-    <span class="n">syllableTier</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="s1">&#39;syllable&#39;</span><span class="p">,</span> <span class="n">syllableEntryList</span><span class="p">,</span>
-                                     <span class="n">minT</span><span class="p">,</span> <span class="n">maxT</span><span class="p">)</span>
-    <span class="n">tonicSTier</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="s1">&#39;tonicSyllable&#39;</span><span class="p">,</span> <span class="n">tonicSEntryList</span><span class="p">,</span>
-                                   <span class="n">minT</span><span class="p">,</span> <span class="n">maxT</span><span class="p">)</span>
-    <span class="n">tonicPTier</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="s1">&#39;tonicVowel&#39;</span><span class="p">,</span> <span class="n">tonicPEntryList</span><span class="p">,</span>
-                                   <span class="n">minT</span><span class="p">,</span> <span class="n">maxT</span><span class="p">)</span>
+    <span class="n">syllableTier</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="s1">&#39;syllable&#39;</span><span class="p">,</span> <span class="n">syllableEntryList</span><span class="p">,</span>
+                                         <span class="n">minT</span><span class="p">,</span> <span class="n">maxT</span><span class="p">)</span>
+    <span class="n">tonicSTier</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="s1">&#39;tonicSyllable&#39;</span><span class="p">,</span> <span class="n">tonicSEntryList</span><span class="p">,</span>
+                                       <span class="n">minT</span><span class="p">,</span> <span class="n">maxT</span><span class="p">)</span>
+    <span class="n">tonicPTier</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="s1">&#39;tonicVowel&#39;</span><span class="p">,</span> <span class="n">tonicPEntryList</span><span class="p">,</span>
+                                       <span class="n">minT</span><span class="p">,</span> <span class="n">maxT</span><span class="p">)</span>
 
-    <span class="n">syllableTG</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">Textgrid</span><span class="p">()</span>
+    <span class="n">syllableTG</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">Textgrid</span><span class="p">()</span>
     <span class="n">syllableTG</span><span class="o">.</span><span class="n">addTier</span><span class="p">(</span><span class="n">syllableTier</span><span class="p">)</span>
     <span class="n">syllableTG</span><span class="o">.</span><span class="n">addTier</span><span class="p">(</span><span class="n">tonicSTier</span><span class="p">)</span>
     <span class="n">syllableTG</span><span class="o">.</span><span class="n">addTier</span><span class="p">(</span><span class="n">tonicPTier</span><span class="p">)</span>
 
     <span class="k">return</span> <span class="n">syllableTG</span>
+
+<span class="k">class</span> <span class="nc">StressedSyllableDetectionError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">word</span><span class="p">,</span> <span class="n">phoneList</span><span class="p">,</span> <span class="n">syllableList</span><span class="p">,</span> <span class="n">islesAdjustedSyllableList</span><span class="p">):</span>
+        <span class="nb">super</span><span class="p">(</span><span class="n">StressedSyllableDetectionError</span><span class="p">,</span> <span class="bp">self</span><span class="p">)</span><span class="o">.</span><span class="fm">__init__</span><span class="p">()</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">word</span> <span class="o">=</span> <span class="n">word</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">phoneList</span> <span class="o">=</span> <span class="n">phoneList</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">syllableList</span> <span class="o">=</span> <span class="n">syllableList</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">islesAdjustedSyllableList</span> <span class="o">=</span> <span class="n">islesAdjustedSyllableList</span>
+
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="p">(</span><span class="sa">f</span><span class="s2">&quot;</span><span class="se">\n</span><span class="s2">For the word &#39;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">word</span><span class="si">}</span><span class="s2">&#39; the actual pronunciation was </span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">phoneList</span><span class="si">}</span><span class="se">\n\n</span><span class="s2">&quot;</span>
+                 <span class="sa">f</span><span class="s2">&quot;this tool attempted to map your phone list with ISLE&#39;s syllable list</span><span class="se">\n</span><span class="s2">&quot;</span>
+                 <span class="sa">f</span><span class="s2">&quot;your mapped syllable list </span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">syllableList</span><span class="si">}</span><span class="se">\n</span><span class="s2">&quot;</span>
+                 <span class="sa">f</span><span class="s2">&quot;isle&#39;s adjusted syllable list </span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">islesAdjustedSyllableList</span><span class="si">}</span><span class="se">\n\n</span><span class="s2">&quot;</span>
+                 <span class="s2">&quot;This commonly happens due to speech errors--when the speaker adds or removes an entire syllable.&quot;</span>
+                 <span class="s2">&quot;You can get around this by </span><span class="se">\n</span><span class="s2">&quot;</span>
+                 <span class="s2">&quot;    1) adding an entry to the ISLEdict (in alphabetical order) with the same structure as the actual pronunciation.</span><span class="se">\n</span><span class="s2">&quot;</span>
+                 <span class="s2">&quot;    2) silencing errors by setting &#39;stressedSyllableDetectionErrors&#39; to &#39;SKIP&#39; or &#39;WARN&#39;&quot;</span>
+                 <span class="p">)</span>
 </pre></div>
 
         </details>
@@ -610,10 +666,10 @@
         <span class="n">phoneEntryList</span><span class="o">.</span><span class="n">extend</span><span class="p">(</span><span class="n">subPhoneEntryList</span><span class="p">)</span>
 
     <span class="c1"># Replace or add the word tier</span>
-    <span class="n">newWordTier</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="n">wordTierName</span><span class="p">,</span>
-                                    <span class="n">wordEntryList</span><span class="p">,</span>
-                                    <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span>
-                                    <span class="n">tg</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">)</span>
+    <span class="n">newWordTier</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="n">wordTierName</span><span class="p">,</span>
+                                        <span class="n">wordEntryList</span><span class="p">,</span>
+                                        <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span>
+                                        <span class="n">tg</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">)</span>
     <span class="k">if</span> <span class="n">wordTier</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
         <span class="n">tg</span><span class="o">.</span><span class="n">replaceTier</span><span class="p">(</span><span class="n">wordTierName</span><span class="p">,</span> <span class="n">newWordTier</span><span class="p">)</span>
     <span class="k">else</span><span class="p">:</span>
@@ -623,10 +679,10 @@
     <span class="c1"># Add the phone tier</span>
     <span class="c1"># This is mainly used as an annotation tier</span>
     <span class="k">if</span> <span class="n">phoneHelperTierName</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="ow">and</span> <span class="nb">len</span><span class="p">(</span><span class="n">phoneEntryList</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
-        <span class="n">newPhoneTier</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="n">phoneHelperTierName</span><span class="p">,</span>
-                                         <span class="n">phoneEntryList</span><span class="p">,</span>
-                                         <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span>
-                                         <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">)</span>
+        <span class="n">newPhoneTier</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="n">phoneHelperTierName</span><span class="p">,</span>
+                                             <span class="n">phoneEntryList</span><span class="p">,</span>
+                                             <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span>
+                                             <span class="n">tg</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">)</span>
         <span class="k">if</span> <span class="n">phoneHelperTierName</span> <span class="ow">in</span> <span class="n">tg</span><span class="o">.</span><span class="n">tierNameList</span><span class="p">:</span>
             <span class="n">tg</span><span class="o">.</span><span class="n">replaceTier</span><span class="p">(</span><span class="n">phoneHelperTierName</span><span class="p">,</span> <span class="n">newPhoneTier</span><span class="p">)</span>
         <span class="k">else</span><span class="p">:</span>
@@ -731,10 +787,10 @@ removeOverlappingSegments - remove any labeled words or phones that
         <span class="n">phoneEntryList</span><span class="o">.</span><span class="n">extend</span><span class="p">(</span><span class="n">subPhoneEntryList</span><span class="p">)</span>
 
     <span class="c1"># Replace or add the phone tier</span>
-    <span class="n">newPhoneTier</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="n">phoneTierName</span><span class="p">,</span>
-                                     <span class="n">phoneEntryList</span><span class="p">,</span>
-                                     <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span>
-                                     <span class="n">tg</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">)</span>
+    <span class="n">newPhoneTier</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="n">phoneTierName</span><span class="p">,</span>
+                                        <span class="n">phoneEntryList</span><span class="p">,</span>
+                                        <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span><span class="p">,</span>
+                                        <span class="n">tg</span><span class="o">.</span><span class="n">maxTimestamp</span><span class="p">)</span>
     <span class="k">if</span> <span class="n">phoneTier</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
         <span class="n">tg</span><span class="o">.</span><span class="n">replaceTier</span><span class="p">(</span><span class="n">phoneTierName</span><span class="p">,</span> <span class="n">newPhoneTier</span><span class="p">)</span>
     <span class="k">else</span><span class="p">:</span>
@@ -770,14 +826,18 @@ and the number of phones.</p>
     phoneTierName,
     skipLabelList=None,
     startT=None,
-    stopT=None
+    stopT=None,
+    stressedSyllableDetectionErrors=&#39;ERROR&#39;,
+    syllabificationError=&#39;ERROR&#39;
 )</span>:
     </div>
 
                 <details>
             <summary>View Source</summary>
             <div class="codehilite"><pre><span></span><span class="k">def</span> <span class="nf">syllabifyTextgrid</span><span class="p">(</span><span class="n">isleDict</span><span class="p">,</span> <span class="n">tg</span><span class="p">,</span> <span class="n">wordTierName</span><span class="p">,</span> <span class="n">phoneTierName</span><span class="p">,</span>
-                      <span class="n">skipLabelList</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">startT</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">stopT</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
+                      <span class="n">skipLabelList</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">startT</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">stopT</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+                      <span class="n">stressedSyllableDetectionErrors</span><span class="o">=</span><span class="s2">&quot;ERROR&quot;</span><span class="p">,</span>
+                      <span class="n">syllabificationError</span><span class="o">=</span><span class="s2">&quot;ERROR&quot;</span><span class="p">):</span>
     <span class="sd">&#39;&#39;&#39;</span>
 <span class="sd">    Given a textgrid, syllabifies the phones in the textgrid</span>
 
@@ -789,6 +849,12 @@ and the number of phones.</p>
 <span class="sd">    Returns a textgrid with only two tiers containing syllable information</span>
 <span class="sd">    (syllabification of the phone tier and a tier marking word-stress).</span>
 <span class="sd">    &#39;&#39;&#39;</span>
+
+    <span class="k">if</span> <span class="n">stressedSyllableDetectionErrors</span> <span class="ow">not</span> <span class="ow">in</span> <span class="p">[</span><span class="s2">&quot;IGNORE&quot;</span><span class="p">,</span> <span class="s2">&quot;WARN&quot;</span><span class="p">,</span> <span class="s2">&quot;ERROR&quot;</span><span class="p">]:</span>
+        <span class="k">raise</span> <span class="s2">&quot;Function argument &#39;stressedSyllableDetectionErrors&#39; must be one of &#39;IGNORE&#39;, &#39;WARN&#39;, or &#39;ERROR&#39;&quot;</span>
+    <span class="k">if</span> <span class="n">syllabificationError</span> <span class="ow">not</span> <span class="ow">in</span> <span class="p">[</span><span class="s2">&quot;IGNORE&quot;</span><span class="p">,</span> <span class="s2">&quot;WARN&quot;</span><span class="p">,</span> <span class="s2">&quot;ERROR&quot;</span><span class="p">]:</span>
+        <span class="k">raise</span> <span class="s2">&quot;Function argument &#39;syllabificationError&#39; must be one of &#39;IGNORE&#39;, &#39;WARN&#39;, or &#39;ERROR&#39;&quot;</span>
+
     <span class="n">minT</span> <span class="o">=</span> <span class="n">tg</span><span class="o">.</span><span class="n">minTimestamp</span>
     <span class="n">maxT</span> <span class="o">=</span> <span class="n">tg</span><span class="o">.</span><span class="n">maxTimestamp</span>
 
@@ -825,19 +891,27 @@ and the number of phones.</p>
             <span class="n">sylTmp</span> <span class="o">=</span> <span class="n">pronunciationtools</span><span class="o">.</span><span class="n">findBestSyllabification</span><span class="p">(</span><span class="n">isleDict</span><span class="p">,</span>
                                                                 <span class="n">word</span><span class="p">,</span>
                                                                 <span class="n">phoneList</span><span class="p">)</span>
+
         <span class="k">except</span> <span class="n">isletool</span><span class="o">.</span><span class="n">WordNotInISLE</span><span class="p">:</span>
-            <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Word (&#39;</span><span class="si">%s</span><span class="s2">&#39;) not is isle -- skipping syllabification&quot;</span> <span class="o">%</span> <span class="n">word</span><span class="p">)</span>
+            <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Not is isle -- skipping syllabification; Word &#39;</span><span class="si">{</span><span class="n">word</span><span class="si">}</span><span class="s2">&#39; at </span><span class="si">{</span><span class="n">start</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
             <span class="k">continue</span>
         <span class="k">except</span> <span class="n">pronunciationtools</span><span class="o">.</span><span class="n">NullPronunciationError</span><span class="p">:</span>
-            <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Word (&#39;</span><span class="si">%s</span><span class="s2">&#39;) has no provided pronunciation&quot;</span> <span class="o">%</span> <span class="n">word</span><span class="p">)</span>
+            <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;No provided pronunciation; Word &#39;</span><span class="si">{</span><span class="n">word</span><span class="si">}</span><span class="s2">&#39; at </span><span class="si">{</span><span class="n">start</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
             <span class="k">continue</span>
-        <span class="k">except</span> <span class="ne">AssertionError</span><span class="p">:</span>
-            <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Unable to syllabify &#39;</span><span class="si">%s</span><span class="s2">&#39;&quot;</span> <span class="o">%</span> <span class="n">word</span><span class="p">)</span>
-            <span class="k">continue</span>
+        <span class="k">except</span> <span class="n">pronunciationtools</span><span class="o">.</span><span class="n">ImpossibleSyllabificationError</span> <span class="k">as</span> <span class="n">e</span><span class="p">:</span>
+            <span class="k">if</span> <span class="n">syllabificationError</span> <span class="o">==</span> <span class="s1">&#39;SKIP&#39;</span><span class="p">:</span>
+                <span class="k">continue</span>
+
+            <span class="k">if</span> <span class="n">syllabificationError</span> <span class="o">==</span> <span class="s1">&#39;WARN&#39;</span><span class="p">:</span>
+                <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Syllabification error; Word &#39;</span><span class="si">{</span><span class="n">word</span><span class="si">}</span><span class="s2">&#39; at </span><span class="si">{</span><span class="n">start</span><span class="si">}</span><span class="s2">; &quot;</span> <span class="o">+</span> <span class="nb">str</span><span class="p">(</span><span class="n">e</span><span class="p">))</span>
+                <span class="k">continue</span>
+
+            <span class="k">raise</span>
 
         <span class="n">stressI</span> <span class="o">=</span> <span class="n">sylTmp</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
         <span class="n">stressJ</span> <span class="o">=</span> <span class="n">sylTmp</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span>
         <span class="n">syllableList</span> <span class="o">=</span> <span class="n">sylTmp</span><span class="p">[</span><span class="mi">2</span><span class="p">]</span>
+        <span class="n">islesAdjustedSyllableList</span> <span class="o">=</span> <span class="n">sylTmp</span><span class="p">[</span><span class="mi">3</span><span class="p">]</span>
 
         <span class="k">if</span> <span class="n">stressI</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="ow">and</span> <span class="n">stressJ</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
             <span class="n">syllableList</span><span class="p">[</span><span class="n">stressI</span><span class="p">][</span><span class="n">stressJ</span><span class="p">]</span> <span class="o">+=</span> <span class="sa">u</span><span class="s2">&quot;ˈ&quot;</span>
@@ -870,31 +944,42 @@ and the number of phones.</p>
                                                    <span class="n">syllableEnd</span><span class="p">,</span>
                                                    <span class="s2">&quot;strict&quot;</span><span class="p">,</span> <span class="kc">False</span><span class="p">)</span>
 
-                <span class="n">phoneList</span> <span class="o">=</span> <span class="p">[</span><span class="n">entry</span> <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">syllablePhoneTier</span><span class="o">.</span><span class="n">entryList</span>
+                <span class="n">syllablePhoneList</span> <span class="o">=</span> <span class="p">[</span><span class="n">entry</span> <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">syllablePhoneTier</span><span class="o">.</span><span class="n">entryList</span>
                              <span class="k">if</span> <span class="n">entry</span><span class="p">[</span><span class="mi">2</span><span class="p">]</span> <span class="o">!=</span> <span class="s1">&#39;&#39;</span><span class="p">]</span>
-                <span class="n">justPhones</span> <span class="o">=</span> <span class="p">[</span><span class="n">phone</span> <span class="k">for</span> <span class="n">_</span><span class="p">,</span> <span class="n">_</span><span class="p">,</span> <span class="n">phone</span> <span class="ow">in</span> <span class="n">phoneList</span><span class="p">]</span>
+                <span class="n">justPhones</span> <span class="o">=</span> <span class="p">[</span><span class="n">phone</span> <span class="k">for</span> <span class="n">_</span><span class="p">,</span> <span class="n">_</span><span class="p">,</span> <span class="n">phone</span> <span class="ow">in</span> <span class="n">syllablePhoneList</span><span class="p">]</span>
                 <span class="n">cvList</span> <span class="o">=</span> <span class="n">pronunciationtools</span><span class="o">.</span><span class="n">simplifyPronunciation</span><span class="p">(</span><span class="n">justPhones</span><span class="p">)</span>
 
+                <span class="n">tmpStressJ</span> <span class="o">=</span> <span class="kc">None</span>
                 <span class="k">try</span><span class="p">:</span>
                     <span class="n">tmpStressJ</span> <span class="o">=</span> <span class="n">cvList</span><span class="o">.</span><span class="n">index</span><span class="p">(</span><span class="s1">&#39;V&#39;</span><span class="p">)</span>
                 <span class="k">except</span> <span class="ne">ValueError</span><span class="p">:</span>
-                    <span class="k">for</span> <span class="n">char</span> <span class="ow">in</span> <span class="p">[</span><span class="sa">u</span><span class="s1">&#39;r&#39;</span><span class="p">,</span> <span class="sa">u</span><span class="s1">&#39;n&#39;</span><span class="p">,</span> <span class="sa">u</span><span class="s1">&#39;l&#39;</span><span class="p">]:</span>
+                    <span class="k">for</span> <span class="n">char</span> <span class="ow">in</span> <span class="p">[</span><span class="sa">u</span><span class="s1">&#39;r&#39;</span><span class="p">,</span> <span class="sa">u</span><span class="s1">&#39;m&#39;</span><span class="p">,</span> <span class="sa">u</span><span class="s1">&#39;n&#39;</span><span class="p">,</span> <span class="sa">u</span><span class="s1">&#39;l&#39;</span><span class="p">]:</span>
                         <span class="k">if</span> <span class="n">char</span> <span class="ow">in</span> <span class="n">cvList</span><span class="p">:</span>
                             <span class="n">tmpStressJ</span> <span class="o">=</span> <span class="n">cvList</span><span class="o">.</span><span class="n">index</span><span class="p">(</span><span class="n">char</span><span class="p">)</span>
                             <span class="k">break</span>
 
-                <span class="n">phoneStart</span><span class="p">,</span> <span class="n">phoneEnd</span> <span class="o">=</span> <span class="n">phoneList</span><span class="p">[</span><span class="n">tmpStressJ</span><span class="p">][:</span><span class="mi">2</span><span class="p">]</span>
+                <span class="k">if</span> <span class="n">tmpStressJ</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+                    <span class="k">if</span> <span class="n">stressedSyllableDetectionErrors</span> <span class="o">==</span> <span class="s1">&#39;SKIP&#39;</span><span class="p">:</span>
+                        <span class="k">continue</span>
+
+                    <span class="k">if</span> <span class="n">stressedSyllableDetectionErrors</span> <span class="o">==</span> <span class="s1">&#39;WARN&#39;</span><span class="p">:</span>
+                        <span class="nb">print</span> <span class="p">(</span><span class="sa">f</span><span class="s2">&quot;No stressed syllable; word: &#39;</span><span class="si">{</span><span class="n">word</span><span class="si">}</span><span class="s2">&#39;, actual mapped pronunciation: </span><span class="si">{</span><span class="n">syllableList</span><span class="si">}</span><span class="s2">, ISLE&#39;s mapped pronunciation: </span><span class="si">{</span><span class="n">islesAdjustedSyllableList</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
+                        <span class="k">continue</span>
+
+                    <span class="k">raise</span><span class="p">(</span><span class="n">StressedSyllableDetectionError</span><span class="p">(</span><span class="n">word</span><span class="p">,</span> <span class="n">phoneList</span><span class="p">,</span> <span class="n">syllableList</span><span class="p">,</span> <span class="n">islesAdjustedSyllableList</span><span class="p">))</span>
+
+                <span class="n">phoneStart</span><span class="p">,</span> <span class="n">phoneEnd</span> <span class="o">=</span> <span class="n">syllablePhoneList</span><span class="p">[</span><span class="n">tmpStressJ</span><span class="p">][:</span><span class="mi">2</span><span class="p">]</span>
                 <span class="n">tonicPEntryList</span><span class="o">.</span><span class="n">append</span><span class="p">((</span><span class="n">phoneStart</span><span class="p">,</span> <span class="n">phoneEnd</span><span class="p">,</span> <span class="s1">&#39;T&#39;</span><span class="p">))</span>
 
     <span class="c1"># Create a textgrid with the two syllable-level tiers</span>
-    <span class="n">syllableTier</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="s1">&#39;syllable&#39;</span><span class="p">,</span> <span class="n">syllableEntryList</span><span class="p">,</span>
-                                     <span class="n">minT</span><span class="p">,</span> <span class="n">maxT</span><span class="p">)</span>
-    <span class="n">tonicSTier</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="s1">&#39;tonicSyllable&#39;</span><span class="p">,</span> <span class="n">tonicSEntryList</span><span class="p">,</span>
-                                   <span class="n">minT</span><span class="p">,</span> <span class="n">maxT</span><span class="p">)</span>
-    <span class="n">tonicPTier</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="s1">&#39;tonicVowel&#39;</span><span class="p">,</span> <span class="n">tonicPEntryList</span><span class="p">,</span>
-                                   <span class="n">minT</span><span class="p">,</span> <span class="n">maxT</span><span class="p">)</span>
+    <span class="n">syllableTier</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="s1">&#39;syllable&#39;</span><span class="p">,</span> <span class="n">syllableEntryList</span><span class="p">,</span>
+                                         <span class="n">minT</span><span class="p">,</span> <span class="n">maxT</span><span class="p">)</span>
+    <span class="n">tonicSTier</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="s1">&#39;tonicSyllable&#39;</span><span class="p">,</span> <span class="n">tonicSEntryList</span><span class="p">,</span>
+                                       <span class="n">minT</span><span class="p">,</span> <span class="n">maxT</span><span class="p">)</span>
+    <span class="n">tonicPTier</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">IntervalTier</span><span class="p">(</span><span class="s1">&#39;tonicVowel&#39;</span><span class="p">,</span> <span class="n">tonicPEntryList</span><span class="p">,</span>
+                                       <span class="n">minT</span><span class="p">,</span> <span class="n">maxT</span><span class="p">)</span>
 
-    <span class="n">syllableTG</span> <span class="o">=</span> <span class="n">tgio</span><span class="o">.</span><span class="n">Textgrid</span><span class="p">()</span>
+    <span class="n">syllableTG</span> <span class="o">=</span> <span class="n">textgrid</span><span class="o">.</span><span class="n">Textgrid</span><span class="p">()</span>
     <span class="n">syllableTG</span><span class="o">.</span><span class="n">addTier</span><span class="p">(</span><span class="n">syllableTier</span><span class="p">)</span>
     <span class="n">syllableTG</span><span class="o">.</span><span class="n">addTier</span><span class="p">(</span><span class="n">tonicSTier</span><span class="p">)</span>
     <span class="n">syllableTG</span><span class="o">.</span><span class="n">addTier</span><span class="p">(</span><span class="n">tonicPTier</span><span class="p">)</span>
@@ -916,6 +1001,77 @@ and the number of phones.</p>
 </div>
 
 
+                </section>
+                <section id="StressedSyllableDetectionError">
+                                <div class="attr class">
+        <a class="headerlink" href="#StressedSyllableDetectionError">#&nbsp;&nbsp</a>
+
+        
+        <span class="def">class</span>
+        <span class="name">StressedSyllableDetectionError</span><wbr>(<span class="base">builtins.Exception</span>):
+    </div>
+
+                <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">StressedSyllableDetectionError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">word</span><span class="p">,</span> <span class="n">phoneList</span><span class="p">,</span> <span class="n">syllableList</span><span class="p">,</span> <span class="n">islesAdjustedSyllableList</span><span class="p">):</span>
+        <span class="nb">super</span><span class="p">(</span><span class="n">StressedSyllableDetectionError</span><span class="p">,</span> <span class="bp">self</span><span class="p">)</span><span class="o">.</span><span class="fm">__init__</span><span class="p">()</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">word</span> <span class="o">=</span> <span class="n">word</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">phoneList</span> <span class="o">=</span> <span class="n">phoneList</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">syllableList</span> <span class="o">=</span> <span class="n">syllableList</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">islesAdjustedSyllableList</span> <span class="o">=</span> <span class="n">islesAdjustedSyllableList</span>
+
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="p">(</span><span class="sa">f</span><span class="s2">&quot;</span><span class="se">\n</span><span class="s2">For the word &#39;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">word</span><span class="si">}</span><span class="s2">&#39; the actual pronunciation was </span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">phoneList</span><span class="si">}</span><span class="se">\n\n</span><span class="s2">&quot;</span>
+                 <span class="sa">f</span><span class="s2">&quot;this tool attempted to map your phone list with ISLE&#39;s syllable list</span><span class="se">\n</span><span class="s2">&quot;</span>
+                 <span class="sa">f</span><span class="s2">&quot;your mapped syllable list </span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">syllableList</span><span class="si">}</span><span class="se">\n</span><span class="s2">&quot;</span>
+                 <span class="sa">f</span><span class="s2">&quot;isle&#39;s adjusted syllable list </span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">islesAdjustedSyllableList</span><span class="si">}</span><span class="se">\n\n</span><span class="s2">&quot;</span>
+                 <span class="s2">&quot;This commonly happens due to speech errors--when the speaker adds or removes an entire syllable.&quot;</span>
+                 <span class="s2">&quot;You can get around this by </span><span class="se">\n</span><span class="s2">&quot;</span>
+                 <span class="s2">&quot;    1) adding an entry to the ISLEdict (in alphabetical order) with the same structure as the actual pronunciation.</span><span class="se">\n</span><span class="s2">&quot;</span>
+                 <span class="s2">&quot;    2) silencing errors by setting &#39;stressedSyllableDetectionErrors&#39; to &#39;SKIP&#39; or &#39;WARN&#39;&quot;</span>
+                 <span class="p">)</span>
+</pre></div>
+
+        </details>
+
+            <div class="docstring"><p>Common base class for all non-exit exceptions.</p>
+</div>
+
+
+                            <div id="StressedSyllableDetectionError.__init__" class="classattr">
+                                        <div class="attr function"><a class="headerlink" href="#StressedSyllableDetectionError.__init__">#&nbsp;&nbsp</a>
+
+        
+            <span class="name">StressedSyllableDetectionError</span><span class="signature">(word, phoneList, syllableList, islesAdjustedSyllableList)</span>
+    </div>
+
+                <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">word</span><span class="p">,</span> <span class="n">phoneList</span><span class="p">,</span> <span class="n">syllableList</span><span class="p">,</span> <span class="n">islesAdjustedSyllableList</span><span class="p">):</span>
+        <span class="nb">super</span><span class="p">(</span><span class="n">StressedSyllableDetectionError</span><span class="p">,</span> <span class="bp">self</span><span class="p">)</span><span class="o">.</span><span class="fm">__init__</span><span class="p">()</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">word</span> <span class="o">=</span> <span class="n">word</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">phoneList</span> <span class="o">=</span> <span class="n">phoneList</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">syllableList</span> <span class="o">=</span> <span class="n">syllableList</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">islesAdjustedSyllableList</span> <span class="o">=</span> <span class="n">islesAdjustedSyllableList</span>
+</pre></div>
+
+        </details>
+
+    
+
+                            </div>
+                            <div class="inherited">
+                                <h5>Inherited Members</h5>
+                                <dl>
+                                    <div><dt>builtins.BaseException</dt>
+                                <dd id="StressedSyllableDetectionError.with_traceback" class="function">with_traceback</dd>
+                <dd id="StressedSyllableDetectionError.args" class="variable">args</dd>
+
+            </div>
+                                </dl>
+                            </div>
                 </section>
     </main>
             <script>/** elasticlunr - http://weixsong.github.io * Copyright (C) 2017 Oliver Nightingale * Copyright (C) 2017 Wei Song * MIT Licensed */!function(){function e(e){if(null===e||"object"!=typeof e)return e;var t=e.constructor();for(var n in e)e.hasOwnProperty(n)&&(t[n]=e[n]);return t}var t=function(e){var n=new t.Index;return n.pipeline.add(t.trimmer,t.stopWordFilter,t.stemmer),e&&e.call(n,n),n};t.version="0.9.5",lunr=t,t.utils={},t.utils.warn=function(e){return function(t){e.console&&console.warn&&console.warn(t)}}(this),t.utils.toString=function(e){return void 0===e||null===e?"":e.toString()},t.EventEmitter=function(){this.events={}},t.EventEmitter.prototype.addListener=function(){var e=Array.prototype.slice.call(arguments),t=e.pop(),n=e;if("function"!=typeof t)throw new TypeError("last argument must be a function");n.forEach(function(e){this.hasHandler(e)||(this.events[e]=[]),this.events[e].push(t)},this)},t.EventEmitter.prototype.removeListener=function(e,t){if(this.hasHandler(e)){var n=this.events[e].indexOf(t);-1!==n&&(this.events[e].splice(n,1),0==this.events[e].length&&delete this.events[e])}},t.EventEmitter.prototype.emit=function(e){if(this.hasHandler(e)){var t=Array.prototype.slice.call(arguments,1);this.events[e].forEach(function(e){e.apply(void 0,t)},this)}},t.EventEmitter.prototype.hasHandler=function(e){return e in this.events},t.tokenizer=function(e){if(!arguments.length||null===e||void 0===e)return[];if(Array.isArray(e)){var n=e.filter(function(e){return null===e||void 0===e?!1:!0});n=n.map(function(e){return t.utils.toString(e).toLowerCase()});var i=[];return n.forEach(function(e){var n=e.split(t.tokenizer.seperator);i=i.concat(n)},this),i}return e.toString().trim().toLowerCase().split(t.tokenizer.seperator)},t.tokenizer.defaultSeperator=/[\s\-]+/,t.tokenizer.seperator=t.tokenizer.defaultSeperator,t.tokenizer.setSeperator=function(e){null!==e&&void 0!==e&&"object"==typeof e&&(t.tokenizer.seperator=e)},t.tokenizer.resetSeperator=function(){t.tokenizer.seperator=t.tokenizer.defaultSeperator},t.tokenizer.getSeperator=function(){return t.tokenizer.seperator},t.Pipeline=function(){this._queue=[]},t.Pipeline.registeredFunctions={},t.Pipeline.registerFunction=function(e,n){n in t.Pipeline.registeredFunctions&&t.utils.warn("Overwriting existing registered function: "+n),e.label=n,t.Pipeline.registeredFunctions[n]=e},t.Pipeline.getRegisteredFunction=function(e){return e in t.Pipeline.registeredFunctions!=!0?null:t.Pipeline.registeredFunctions[e]},t.Pipeline.warnIfFunctionNotRegistered=function(e){var n=e.label&&e.label in this.registeredFunctions;n||t.utils.warn("Function is not registered with pipeline. This may cause problems when serialising the index.\n",e)},t.Pipeline.load=function(e){var n=new t.Pipeline;return e.forEach(function(e){var i=t.Pipeline.getRegisteredFunction(e);if(!i)throw new Error("Cannot load un-registered function: "+e);n.add(i)}),n},t.Pipeline.prototype.add=function(){var e=Array.prototype.slice.call(arguments);e.forEach(function(e){t.Pipeline.warnIfFunctionNotRegistered(e),this._queue.push(e)},this)},t.Pipeline.prototype.after=function(e,n){t.Pipeline.warnIfFunctionNotRegistered(n);var i=this._queue.indexOf(e);if(-1===i)throw new Error("Cannot find existingFn");this._queue.splice(i+1,0,n)},t.Pipeline.prototype.before=function(e,n){t.Pipeline.warnIfFunctionNotRegistered(n);var i=this._queue.indexOf(e);if(-1===i)throw new Error("Cannot find existingFn");this._queue.splice(i,0,n)},t.Pipeline.prototype.remove=function(e){var t=this._queue.indexOf(e);-1!==t&&this._queue.splice(t,1)},t.Pipeline.prototype.run=function(e){for(var t=[],n=e.length,i=this._queue.length,o=0;n>o;o++){for(var r=e[o],s=0;i>s&&(r=this._queue[s](r,o,e),void 0!==r&&null!==r);s++);void 0!==r&&null!==r&&t.push(r)}return t},t.Pipeline.prototype.reset=function(){this._queue=[]},t.Pipeline.prototype.get=function(){return this._queue},t.Pipeline.prototype.toJSON=function(){return this._queue.map(function(e){return t.Pipeline.warnIfFunctionNotRegistered(e),e.label})},t.Index=function(){this._fields=[],this._ref="id",this.pipeline=new t.Pipeline,this.documentStore=new t.DocumentStore,this.index={},this.eventEmitter=new t.EventEmitter,this._idfCache={},this.on("add","remove","update",function(){this._idfCache={}}.bind(this))},t.Index.prototype.on=function(){var e=Array.prototype.slice.call(arguments);return this.eventEmitter.addListener.apply(this.eventEmitter,e)},t.Index.prototype.off=function(e,t){return this.eventEmitter.removeListener(e,t)},t.Index.load=function(e){e.version!==t.version&&t.utils.warn("version mismatch: current "+t.version+" importing "+e.version);var n=new this;n._fields=e.fields,n._ref=e.ref,n.documentStore=t.DocumentStore.load(e.documentStore),n.pipeline=t.Pipeline.load(e.pipeline),n.index={};for(var i in e.index)n.index[i]=t.InvertedIndex.load(e.index[i]);return n},t.Index.prototype.addField=function(e){return this._fields.push(e),this.index[e]=new t.InvertedIndex,this},t.Index.prototype.setRef=function(e){return this._ref=e,this},t.Index.prototype.saveDocument=function(e){return this.documentStore=new t.DocumentStore(e),this},t.Index.prototype.addDoc=function(e,n){if(e){var n=void 0===n?!0:n,i=e[this._ref];this.documentStore.addDoc(i,e),this._fields.forEach(function(n){var o=this.pipeline.run(t.tokenizer(e[n]));this.documentStore.addFieldLength(i,n,o.length);var r={};o.forEach(function(e){e in r?r[e]+=1:r[e]=1},this);for(var s in r){var u=r[s];u=Math.sqrt(u),this.index[n].addToken(s,{ref:i,tf:u})}},this),n&&this.eventEmitter.emit("add",e,this)}},t.Index.prototype.removeDocByRef=function(e){if(e&&this.documentStore.isDocStored()!==!1&&this.documentStore.hasDoc(e)){var t=this.documentStore.getDoc(e);this.removeDoc(t,!1)}},t.Index.prototype.removeDoc=function(e,n){if(e){var n=void 0===n?!0:n,i=e[this._ref];this.documentStore.hasDoc(i)&&(this.documentStore.removeDoc(i),this._fields.forEach(function(n){var o=this.pipeline.run(t.tokenizer(e[n]));o.forEach(function(e){this.index[n].removeToken(e,i)},this)},this),n&&this.eventEmitter.emit("remove",e,this))}},t.Index.prototype.updateDoc=function(e,t){var t=void 0===t?!0:t;this.removeDocByRef(e[this._ref],!1),this.addDoc(e,!1),t&&this.eventEmitter.emit("update",e,this)},t.Index.prototype.idf=function(e,t){var n="@"+t+"/"+e;if(Object.prototype.hasOwnProperty.call(this._idfCache,n))return this._idfCache[n];var i=this.index[t].getDocFreq(e),o=1+Math.log(this.documentStore.length/(i+1));return this._idfCache[n]=o,o},t.Index.prototype.getFields=function(){return this._fields.slice()},t.Index.prototype.search=function(e,n){if(!e)return[];e="string"==typeof e?{any:e}:JSON.parse(JSON.stringify(e));var i=null;null!=n&&(i=JSON.stringify(n));for(var o=new t.Configuration(i,this.getFields()).get(),r={},s=Object.keys(e),u=0;u<s.length;u++){var a=s[u];r[a]=this.pipeline.run(t.tokenizer(e[a]))}var l={};for(var c in o){var d=r[c]||r.any;if(d){var f=this.fieldSearch(d,c,o),h=o[c].boost;for(var p in f)f[p]=f[p]*h;for(var p in f)p in l?l[p]+=f[p]:l[p]=f[p]}}var v,g=[];for(var p in l)v={ref:p,score:l[p]},this.documentStore.hasDoc(p)&&(v.doc=this.documentStore.getDoc(p)),g.push(v);return g.sort(function(e,t){return t.score-e.score}),g},t.Index.prototype.fieldSearch=function(e,t,n){var i=n[t].bool,o=n[t].expand,r=n[t].boost,s=null,u={};return 0!==r?(e.forEach(function(e){var n=[e];1==o&&(n=this.index[t].expandToken(e));var r={};n.forEach(function(n){var o=this.index[t].getDocs(n),a=this.idf(n,t);if(s&&"AND"==i){var l={};for(var c in s)c in o&&(l[c]=o[c]);o=l}n==e&&this.fieldSearchStats(u,n,o);for(var c in o){var d=this.index[t].getTermFrequency(n,c),f=this.documentStore.getFieldLength(c,t),h=1;0!=f&&(h=1/Math.sqrt(f));var p=1;n!=e&&(p=.15*(1-(n.length-e.length)/n.length));var v=d*a*h*p;c in r?r[c]+=v:r[c]=v}},this),s=this.mergeScores(s,r,i)},this),s=this.coordNorm(s,u,e.length)):void 0},t.Index.prototype.mergeScores=function(e,t,n){if(!e)return t;if("AND"==n){var i={};for(var o in t)o in e&&(i[o]=e[o]+t[o]);return i}for(var o in t)o in e?e[o]+=t[o]:e[o]=t[o];return e},t.Index.prototype.fieldSearchStats=function(e,t,n){for(var i in n)i in e?e[i].push(t):e[i]=[t]},t.Index.prototype.coordNorm=function(e,t,n){for(var i in e)if(i in t){var o=t[i].length;e[i]=e[i]*o/n}return e},t.Index.prototype.toJSON=function(){var e={};return this._fields.forEach(function(t){e[t]=this.index[t].toJSON()},this),{version:t.version,fields:this._fields,ref:this._ref,documentStore:this.documentStore.toJSON(),index:e,pipeline:this.pipeline.toJSON()}},t.Index.prototype.use=function(e){var t=Array.prototype.slice.call(arguments,1);t.unshift(this),e.apply(this,t)},t.DocumentStore=function(e){this._save=null===e||void 0===e?!0:e,this.docs={},this.docInfo={},this.length=0},t.DocumentStore.load=function(e){var t=new this;return t.length=e.length,t.docs=e.docs,t.docInfo=e.docInfo,t._save=e.save,t},t.DocumentStore.prototype.isDocStored=function(){return this._save},t.DocumentStore.prototype.addDoc=function(t,n){this.hasDoc(t)||this.length++,this.docs[t]=this._save===!0?e(n):null},t.DocumentStore.prototype.getDoc=function(e){return this.hasDoc(e)===!1?null:this.docs[e]},t.DocumentStore.prototype.hasDoc=function(e){return e in this.docs},t.DocumentStore.prototype.removeDoc=function(e){this.hasDoc(e)&&(delete this.docs[e],delete this.docInfo[e],this.length--)},t.DocumentStore.prototype.addFieldLength=function(e,t,n){null!==e&&void 0!==e&&0!=this.hasDoc(e)&&(this.docInfo[e]||(this.docInfo[e]={}),this.docInfo[e][t]=n)},t.DocumentStore.prototype.updateFieldLength=function(e,t,n){null!==e&&void 0!==e&&0!=this.hasDoc(e)&&this.addFieldLength(e,t,n)},t.DocumentStore.prototype.getFieldLength=function(e,t){return null===e||void 0===e?0:e in this.docs&&t in this.docInfo[e]?this.docInfo[e][t]:0},t.DocumentStore.prototype.toJSON=function(){return{docs:this.docs,docInfo:this.docInfo,length:this.length,save:this._save}},t.stemmer=function(){var e={ational:"ate",tional:"tion",enci:"ence",anci:"ance",izer:"ize",bli:"ble",alli:"al",entli:"ent",eli:"e",ousli:"ous",ization:"ize",ation:"ate",ator:"ate",alism:"al",iveness:"ive",fulness:"ful",ousness:"ous",aliti:"al",iviti:"ive",biliti:"ble",logi:"log"},t={icate:"ic",ative:"",alize:"al",iciti:"ic",ical:"ic",ful:"",ness:""},n="[^aeiou]",i="[aeiouy]",o=n+"[^aeiouy]*",r=i+"[aeiou]*",s="^("+o+")?"+r+o,u="^("+o+")?"+r+o+"("+r+")?$",a="^("+o+")?"+r+o+r+o,l="^("+o+")?"+i,c=new RegExp(s),d=new RegExp(a),f=new RegExp(u),h=new RegExp(l),p=/^(.+?)(ss|i)es$/,v=/^(.+?)([^s])s$/,g=/^(.+?)eed$/,m=/^(.+?)(ed|ing)$/,y=/.$/,S=/(at|bl|iz)$/,x=new RegExp("([^aeiouylsz])\\1$"),w=new RegExp("^"+o+i+"[^aeiouwxy]$"),I=/^(.+?[^aeiou])y$/,b=/^(.+?)(ational|tional|enci|anci|izer|bli|alli|entli|eli|ousli|ization|ation|ator|alism|iveness|fulness|ousness|aliti|iviti|biliti|logi)$/,E=/^(.+?)(icate|ative|alize|iciti|ical|ful|ness)$/,D=/^(.+?)(al|ance|ence|er|ic|able|ible|ant|ement|ment|ent|ou|ism|ate|iti|ous|ive|ize)$/,F=/^(.+?)(s|t)(ion)$/,_=/^(.+?)e$/,P=/ll$/,k=new RegExp("^"+o+i+"[^aeiouwxy]$"),z=function(n){var i,o,r,s,u,a,l;if(n.length<3)return n;if(r=n.substr(0,1),"y"==r&&(n=r.toUpperCase()+n.substr(1)),s=p,u=v,s.test(n)?n=n.replace(s,"$1$2"):u.test(n)&&(n=n.replace(u,"$1$2")),s=g,u=m,s.test(n)){var z=s.exec(n);s=c,s.test(z[1])&&(s=y,n=n.replace(s,""))}else if(u.test(n)){var z=u.exec(n);i=z[1],u=h,u.test(i)&&(n=i,u=S,a=x,l=w,u.test(n)?n+="e":a.test(n)?(s=y,n=n.replace(s,"")):l.test(n)&&(n+="e"))}if(s=I,s.test(n)){var z=s.exec(n);i=z[1],n=i+"i"}if(s=b,s.test(n)){var z=s.exec(n);i=z[1],o=z[2],s=c,s.test(i)&&(n=i+e[o])}if(s=E,s.test(n)){var z=s.exec(n);i=z[1],o=z[2],s=c,s.test(i)&&(n=i+t[o])}if(s=D,u=F,s.test(n)){var z=s.exec(n);i=z[1],s=d,s.test(i)&&(n=i)}else if(u.test(n)){var z=u.exec(n);i=z[1]+z[2],u=d,u.test(i)&&(n=i)}if(s=_,s.test(n)){var z=s.exec(n);i=z[1],s=d,u=f,a=k,(s.test(i)||u.test(i)&&!a.test(i))&&(n=i)}return s=P,u=d,s.test(n)&&u.test(n)&&(s=y,n=n.replace(s,"")),"y"==r&&(n=r.toLowerCase()+n.substr(1)),n};return z}(),t.Pipeline.registerFunction(t.stemmer,"stemmer"),t.stopWordFilter=function(e){return e&&t.stopWordFilter.stopWords[e]!==!0?e:void 0},t.clearStopWords=function(){t.stopWordFilter.stopWords={}},t.addStopWords=function(e){null!=e&&Array.isArray(e)!==!1&&e.forEach(function(e){t.stopWordFilter.stopWords[e]=!0},this)},t.resetStopWords=function(){t.stopWordFilter.stopWords=t.defaultStopWords},t.defaultStopWords={"":!0,a:!0,able:!0,about:!0,across:!0,after:!0,all:!0,almost:!0,also:!0,am:!0,among:!0,an:!0,and:!0,any:!0,are:!0,as:!0,at:!0,be:!0,because:!0,been:!0,but:!0,by:!0,can:!0,cannot:!0,could:!0,dear:!0,did:!0,"do":!0,does:!0,either:!0,"else":!0,ever:!0,every:!0,"for":!0,from:!0,get:!0,got:!0,had:!0,has:!0,have:!0,he:!0,her:!0,hers:!0,him:!0,his:!0,how:!0,however:!0,i:!0,"if":!0,"in":!0,into:!0,is:!0,it:!0,its:!0,just:!0,least:!0,let:!0,like:!0,likely:!0,may:!0,me:!0,might:!0,most:!0,must:!0,my:!0,neither:!0,no:!0,nor:!0,not:!0,of:!0,off:!0,often:!0,on:!0,only:!0,or:!0,other:!0,our:!0,own:!0,rather:!0,said:!0,say:!0,says:!0,she:!0,should:!0,since:!0,so:!0,some:!0,than:!0,that:!0,the:!0,their:!0,them:!0,then:!0,there:!0,these:!0,they:!0,"this":!0,tis:!0,to:!0,too:!0,twas:!0,us:!0,wants:!0,was:!0,we:!0,were:!0,what:!0,when:!0,where:!0,which:!0,"while":!0,who:!0,whom:!0,why:!0,will:!0,"with":!0,would:!0,yet:!0,you:!0,your:!0},t.stopWordFilter.stopWords=t.defaultStopWords,t.Pipeline.registerFunction(t.stopWordFilter,"stopWordFilter"),t.trimmer=function(e){if(null===e||void 0===e)throw new Error("token should not be undefined");return e.replace(/^\W+/,"").replace(/\W+$/,"")},t.Pipeline.registerFunction(t.trimmer,"trimmer"),t.InvertedIndex=function(){this.root={docs:{},df:0}},t.InvertedIndex.load=function(e){var t=new this;return t.root=e.root,t},t.InvertedIndex.prototype.addToken=function(e,t,n){for(var n=n||this.root,i=0;i<=e.length-1;){var o=e[i];o in n||(n[o]={docs:{},df:0}),i+=1,n=n[o]}var r=t.ref;n.docs[r]?n.docs[r]={tf:t.tf}:(n.docs[r]={tf:t.tf},n.df+=1)},t.InvertedIndex.prototype.hasToken=function(e){if(!e)return!1;for(var t=this.root,n=0;n<e.length;n++){if(!t[e[n]])return!1;t=t[e[n]]}return!0},t.InvertedIndex.prototype.getNode=function(e){if(!e)return null;for(var t=this.root,n=0;n<e.length;n++){if(!t[e[n]])return null;t=t[e[n]]}return t},t.InvertedIndex.prototype.getDocs=function(e){var t=this.getNode(e);return null==t?{}:t.docs},t.InvertedIndex.prototype.getTermFrequency=function(e,t){var n=this.getNode(e);return null==n?0:t in n.docs?n.docs[t].tf:0},t.InvertedIndex.prototype.getDocFreq=function(e){var t=this.getNode(e);return null==t?0:t.df},t.InvertedIndex.prototype.removeToken=function(e,t){if(e){var n=this.getNode(e);null!=n&&t in n.docs&&(delete n.docs[t],n.df-=1)}},t.InvertedIndex.prototype.expandToken=function(e,t,n){if(null==e||""==e)return[];var t=t||[];if(void 0==n&&(n=this.getNode(e),null==n))return t;n.df>0&&t.push(e);for(var i in n)"docs"!==i&&"df"!==i&&this.expandToken(e+i,t,n[i]);return t},t.InvertedIndex.prototype.toJSON=function(){return{root:this.root}},t.Configuration=function(e,n){var e=e||"";if(void 0==n||null==n)throw new Error("fields should not be null");this.config={};var i;try{i=JSON.parse(e),this.buildUserConfig(i,n)}catch(o){t.utils.warn("user configuration parse failed, will use default configuration"),this.buildDefaultConfig(n)}},t.Configuration.prototype.buildDefaultConfig=function(e){this.reset(),e.forEach(function(e){this.config[e]={boost:1,bool:"OR",expand:!1}},this)},t.Configuration.prototype.buildUserConfig=function(e,n){var i="OR",o=!1;if(this.reset(),"bool"in e&&(i=e.bool||i),"expand"in e&&(o=e.expand||o),"fields"in e)for(var r in e.fields)if(n.indexOf(r)>-1){var s=e.fields[r],u=o;void 0!=s.expand&&(u=s.expand),this.config[r]={boost:s.boost||0===s.boost?s.boost:1,bool:s.bool||i,expand:u}}else t.utils.warn("field name in user configuration not found in index instance fields");else this.addAllFields2UserConfig(i,o,n)},t.Configuration.prototype.addAllFields2UserConfig=function(e,t,n){n.forEach(function(n){this.config[n]={boost:1,bool:e,expand:t}},this)},t.Configuration.prototype.get=function(){return this.config},t.Configuration.prototype.reset=function(){this.config={}},lunr.SortedSet=function(){this.length=0,this.elements=[]},lunr.SortedSet.load=function(e){var t=new this;return t.elements=e,t.length=e.length,t},lunr.SortedSet.prototype.add=function(){var e,t;for(e=0;e<arguments.length;e++)t=arguments[e],~this.indexOf(t)||this.elements.splice(this.locationFor(t),0,t);this.length=this.elements.length},lunr.SortedSet.prototype.toArray=function(){return this.elements.slice()},lunr.SortedSet.prototype.map=function(e,t){return this.elements.map(e,t)},lunr.SortedSet.prototype.forEach=function(e,t){return this.elements.forEach(e,t)},lunr.SortedSet.prototype.indexOf=function(e){for(var t=0,n=this.elements.length,i=n-t,o=t+Math.floor(i/2),r=this.elements[o];i>1;){if(r===e)return o;e>r&&(t=o),r>e&&(n=o),i=n-t,o=t+Math.floor(i/2),r=this.elements[o]}return r===e?o:-1},lunr.SortedSet.prototype.locationFor=function(e){for(var t=0,n=this.elements.length,i=n-t,o=t+Math.floor(i/2),r=this.elements[o];i>1;)e>r&&(t=o),r>e&&(n=o),i=n-t,o=t+Math.floor(i/2),r=this.elements[o];return r>e?o:e>r?o+1:void 0},lunr.SortedSet.prototype.intersect=function(e){for(var t=new lunr.SortedSet,n=0,i=0,o=this.length,r=e.length,s=this.elements,u=e.elements;;){if(n>o-1||i>r-1)break;s[n]!==u[i]?s[n]<u[i]?n++:s[n]>u[i]&&i++:(t.add(s[n]),n++,i++)}return t},lunr.SortedSet.prototype.clone=function(){var e=new lunr.SortedSet;return e.elements=this.toArray(),e.length=e.elements.length,e},lunr.SortedSet.prototype.union=function(e){var t,n,i;this.length>=e.length?(t=this,n=e):(t=e,n=this),i=t.clone();for(var o=0,r=n.toArray();o<r.length;o++)i.add(r[o]);return i},lunr.SortedSet.prototype.toJSON=function(){return this.toArray()},function(e,t){"function"==typeof define&&define.amd?define(t):"object"==typeof exports?module.exports=t():e.elasticlunr=t()}(this,function(){return t})}();</script>

--- a/docs/pysle/pronunciationtools.html
+++ b/docs/pysle/pronunciationtools.html
@@ -40,6 +40,15 @@
 
             </li>
             <li>
+                    <a class="class" href="#ImpossibleSyllabificationError">ImpossibleSyllabificationError</a>
+                            <ul class="memberlist">
+                        <li>
+                                <a class="function" href="#ImpossibleSyllabificationError.__init__">ImpossibleSyllabificationError</a>
+                        </li>
+                </ul>
+
+            </li>
+            <li>
                     <a class="class" href="#NumWordsMismatchError">NumWordsMismatchError</a>
                             <ul class="memberlist">
                         <li>
@@ -134,6 +143,18 @@
 
         <span class="k">return</span> <span class="n">errStr</span> <span class="o">%</span> <span class="p">(</span><span class="n">syllableStr</span><span class="p">,</span> <span class="n">syllableCVStr</span><span class="p">)</span>
 
+
+<span class="k">class</span> <span class="nc">ImpossibleSyllabificationError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">estimatedActualSyllabificationList</span><span class="p">,</span> <span class="n">isleSyllabificationList</span><span class="p">):</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">estimatedList</span> <span class="o">=</span> <span class="n">estimatedActualSyllabificationList</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">isleSyllabificationList</span> <span class="o">=</span> <span class="n">isleSyllabificationList</span>
+
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Impossible syllabification; &quot;</span>
+            <span class="sa">f</span><span class="s2">&quot;Estimated: </span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">estimatedList</span><span class="si">}</span><span class="s2">; &quot;</span>
+            <span class="sa">f</span><span class="s2">&quot;ISLE&#39;s: </span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">isleSyllabificationList</span><span class="si">}</span><span class="s2">&quot;</span>
+            <span class="p">)</span>
 
 <span class="k">class</span> <span class="nc">NumWordsMismatchError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
 
@@ -392,8 +413,8 @@
 <span class="sd">    &#39;&#39;&#39;</span>
 
     <span class="c1"># Remove any elements not in the other list (but maintain order)</span>
-    <span class="n">pronATmp</span> <span class="o">=</span> <span class="n">phoneListA</span>
-    <span class="n">pronBTmp</span> <span class="o">=</span> <span class="n">phoneListB</span>
+    <span class="n">pronATmp</span> <span class="o">=</span> <span class="n">copy</span><span class="o">.</span><span class="n">deepcopy</span><span class="p">(</span><span class="n">phoneListA</span><span class="p">)</span>
+    <span class="n">pronBTmp</span> <span class="o">=</span> <span class="n">copy</span><span class="o">.</span><span class="n">deepcopy</span><span class="p">(</span><span class="n">phoneListB</span><span class="p">)</span>
 
     <span class="c1"># Find the longest sequence</span>
     <span class="n">sequence</span> <span class="o">=</span> <span class="n">_lcs</span><span class="p">(</span><span class="n">pronBTmp</span><span class="p">,</span> <span class="n">pronATmp</span><span class="p">)</span>
@@ -405,16 +426,16 @@
     <span class="n">sequenceIndexListA</span> <span class="o">=</span> <span class="p">[]</span>
     <span class="n">sequenceIndexListB</span> <span class="o">=</span> <span class="p">[]</span>
     <span class="k">for</span> <span class="n">phone</span> <span class="ow">in</span> <span class="n">sequence</span><span class="p">:</span>
-        <span class="n">startA</span> <span class="o">=</span> <span class="n">phoneListA</span><span class="o">.</span><span class="n">index</span><span class="p">(</span><span class="n">phone</span><span class="p">,</span> <span class="n">startA</span><span class="p">)</span>
-        <span class="n">startB</span> <span class="o">=</span> <span class="n">phoneListB</span><span class="o">.</span><span class="n">index</span><span class="p">(</span><span class="n">phone</span><span class="p">,</span> <span class="n">startB</span><span class="p">)</span>
+        <span class="n">startA</span> <span class="o">=</span> <span class="n">pronATmp</span><span class="o">.</span><span class="n">index</span><span class="p">(</span><span class="n">phone</span><span class="p">,</span> <span class="n">startA</span><span class="p">)</span>
+        <span class="n">startB</span> <span class="o">=</span> <span class="n">pronBTmp</span><span class="o">.</span><span class="n">index</span><span class="p">(</span><span class="n">phone</span><span class="p">,</span> <span class="n">startB</span><span class="p">)</span>
 
         <span class="n">sequenceIndexListA</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">startA</span><span class="p">)</span>
         <span class="n">sequenceIndexListB</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">startB</span><span class="p">)</span>
 
     <span class="c1"># An index on the tail of both will be used to create output strings</span>
     <span class="c1"># of the same length</span>
-    <span class="n">sequenceIndexListA</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">phoneListA</span><span class="p">))</span>
-    <span class="n">sequenceIndexListB</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">phoneListB</span><span class="p">))</span>
+    <span class="n">sequenceIndexListA</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">pronATmp</span><span class="p">))</span>
+    <span class="n">sequenceIndexListB</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">pronBTmp</span><span class="p">))</span>
 
     <span class="c1"># Fill in any blanks such that the sequential items have the same</span>
     <span class="c1"># index and the two strings are the same length</span>
@@ -423,16 +444,16 @@
         <span class="n">indexB</span> <span class="o">=</span> <span class="n">sequenceIndexListB</span><span class="p">[</span><span class="n">i</span><span class="p">]</span>
         <span class="k">if</span> <span class="n">indexA</span> <span class="o">&lt;</span> <span class="n">indexB</span><span class="p">:</span>
             <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="n">indexB</span> <span class="o">-</span> <span class="n">indexA</span><span class="p">):</span>
-                <span class="n">phoneListA</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="n">indexA</span><span class="p">,</span> <span class="s2">&quot;&#39;&#39;&quot;</span><span class="p">)</span>
+                <span class="n">pronATmp</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="n">indexA</span><span class="p">,</span> <span class="s2">&quot;&#39;&#39;&quot;</span><span class="p">)</span>
             <span class="n">sequenceIndexListA</span> <span class="o">=</span> <span class="p">[</span><span class="n">val</span> <span class="o">+</span> <span class="n">indexB</span> <span class="o">-</span> <span class="n">indexA</span>
                                   <span class="k">for</span> <span class="n">val</span> <span class="ow">in</span> <span class="n">sequenceIndexListA</span><span class="p">]</span>
         <span class="k">elif</span> <span class="n">indexA</span> <span class="o">&gt;</span> <span class="n">indexB</span><span class="p">:</span>
             <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="n">indexA</span> <span class="o">-</span> <span class="n">indexB</span><span class="p">):</span>
-                <span class="n">phoneListB</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="n">indexB</span><span class="p">,</span> <span class="s2">&quot;&#39;&#39;&quot;</span><span class="p">)</span>
+                <span class="n">pronBTmp</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="n">indexB</span><span class="p">,</span> <span class="s2">&quot;&#39;&#39;&quot;</span><span class="p">)</span>
             <span class="n">sequenceIndexListB</span> <span class="o">=</span> <span class="p">[</span><span class="n">val</span> <span class="o">+</span> <span class="n">indexA</span> <span class="o">-</span> <span class="n">indexB</span>
                                   <span class="k">for</span> <span class="n">val</span> <span class="ow">in</span> <span class="n">sequenceIndexListB</span><span class="p">]</span>
 
-    <span class="k">return</span> <span class="n">phoneListA</span><span class="p">,</span> <span class="n">phoneListB</span>
+    <span class="k">return</span> <span class="n">pronATmp</span><span class="p">,</span> <span class="n">pronBTmp</span>
 
 
 <span class="k">def</span> <span class="nf">findBestSyllabification</span><span class="p">(</span><span class="n">isleDict</span><span class="p">,</span> <span class="n">wordText</span><span class="p">,</span> <span class="n">phoneList</span><span class="p">):</span>
@@ -480,7 +501,10 @@
         <span class="n">stressedSyllableI</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="n">stressedVowelI</span> <span class="o">=</span> <span class="kc">None</span>
     <span class="k">else</span><span class="p">:</span>
-        <span class="n">stressedVowelI</span> <span class="o">=</span> <span class="n">_getSyllableNucleus</span><span class="p">(</span><span class="n">syllableList</span><span class="p">[</span><span class="n">stressedSyllableI</span><span class="p">])</span>
+        <span class="k">try</span><span class="p">:</span>
+            <span class="n">stressedVowelI</span> <span class="o">=</span> <span class="n">_getSyllableNucleus</span><span class="p">(</span><span class="n">syllableList</span><span class="p">[</span><span class="n">stressedSyllableI</span><span class="p">])</span>
+        <span class="k">except</span> <span class="n">TooManyVowelsInSyllable</span> <span class="k">as</span> <span class="n">err</span><span class="p">:</span>
+            <span class="k">raise</span> <span class="n">ImpossibleSyllabificationError</span><span class="p">(</span><span class="n">syllableList</span><span class="p">,</span> <span class="n">alignedSyllables</span><span class="p">)</span> <span class="kn">from</span> <span class="nn">err</span>
 
     <span class="c1"># Count the index of the stressed phones, if the stress list has</span>
     <span class="c1"># become flattened (no syllable information)</span>
@@ -589,6 +613,66 @@
                                     <div><dt>builtins.BaseException</dt>
                                 <dd id="TooManyVowelsInSyllable.with_traceback" class="function">with_traceback</dd>
                 <dd id="TooManyVowelsInSyllable.args" class="variable">args</dd>
+
+            </div>
+                                </dl>
+                            </div>
+                </section>
+                <section id="ImpossibleSyllabificationError">
+                                <div class="attr class">
+        <a class="headerlink" href="#ImpossibleSyllabificationError">#&nbsp;&nbsp</a>
+
+        
+        <span class="def">class</span>
+        <span class="name">ImpossibleSyllabificationError</span><wbr>(<span class="base">builtins.Exception</span>):
+    </div>
+
+                <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">ImpossibleSyllabificationError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">estimatedActualSyllabificationList</span><span class="p">,</span> <span class="n">isleSyllabificationList</span><span class="p">):</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">estimatedList</span> <span class="o">=</span> <span class="n">estimatedActualSyllabificationList</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">isleSyllabificationList</span> <span class="o">=</span> <span class="n">isleSyllabificationList</span>
+
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="p">(</span><span class="sa">f</span><span class="s2">&quot;Impossible syllabification; &quot;</span>
+            <span class="sa">f</span><span class="s2">&quot;Estimated: </span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">estimatedList</span><span class="si">}</span><span class="s2">; &quot;</span>
+            <span class="sa">f</span><span class="s2">&quot;ISLE&#39;s: </span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">isleSyllabificationList</span><span class="si">}</span><span class="s2">&quot;</span>
+            <span class="p">)</span>
+</pre></div>
+
+        </details>
+
+            <div class="docstring"><p>Common base class for all non-exit exceptions.</p>
+</div>
+
+
+                            <div id="ImpossibleSyllabificationError.__init__" class="classattr">
+                                        <div class="attr function"><a class="headerlink" href="#ImpossibleSyllabificationError.__init__">#&nbsp;&nbsp</a>
+
+        
+            <span class="name">ImpossibleSyllabificationError</span><span class="signature">(estimatedActualSyllabificationList, isleSyllabificationList)</span>
+    </div>
+
+                <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">estimatedActualSyllabificationList</span><span class="p">,</span> <span class="n">isleSyllabificationList</span><span class="p">):</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">estimatedList</span> <span class="o">=</span> <span class="n">estimatedActualSyllabificationList</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">isleSyllabificationList</span> <span class="o">=</span> <span class="n">isleSyllabificationList</span>
+</pre></div>
+
+        </details>
+
+    
+
+                            </div>
+                            <div class="inherited">
+                                <h5>Inherited Members</h5>
+                                <dl>
+                                    <div><dt>builtins.BaseException</dt>
+                                <dd id="ImpossibleSyllabificationError.with_traceback" class="function">with_traceback</dd>
+                <dd id="ImpossibleSyllabificationError.args" class="variable">args</dd>
 
             </div>
                                 </dl>
@@ -895,8 +979,8 @@
 <span class="sd">    &#39;&#39;&#39;</span>
 
     <span class="c1"># Remove any elements not in the other list (but maintain order)</span>
-    <span class="n">pronATmp</span> <span class="o">=</span> <span class="n">phoneListA</span>
-    <span class="n">pronBTmp</span> <span class="o">=</span> <span class="n">phoneListB</span>
+    <span class="n">pronATmp</span> <span class="o">=</span> <span class="n">copy</span><span class="o">.</span><span class="n">deepcopy</span><span class="p">(</span><span class="n">phoneListA</span><span class="p">)</span>
+    <span class="n">pronBTmp</span> <span class="o">=</span> <span class="n">copy</span><span class="o">.</span><span class="n">deepcopy</span><span class="p">(</span><span class="n">phoneListB</span><span class="p">)</span>
 
     <span class="c1"># Find the longest sequence</span>
     <span class="n">sequence</span> <span class="o">=</span> <span class="n">_lcs</span><span class="p">(</span><span class="n">pronBTmp</span><span class="p">,</span> <span class="n">pronATmp</span><span class="p">)</span>
@@ -908,16 +992,16 @@
     <span class="n">sequenceIndexListA</span> <span class="o">=</span> <span class="p">[]</span>
     <span class="n">sequenceIndexListB</span> <span class="o">=</span> <span class="p">[]</span>
     <span class="k">for</span> <span class="n">phone</span> <span class="ow">in</span> <span class="n">sequence</span><span class="p">:</span>
-        <span class="n">startA</span> <span class="o">=</span> <span class="n">phoneListA</span><span class="o">.</span><span class="n">index</span><span class="p">(</span><span class="n">phone</span><span class="p">,</span> <span class="n">startA</span><span class="p">)</span>
-        <span class="n">startB</span> <span class="o">=</span> <span class="n">phoneListB</span><span class="o">.</span><span class="n">index</span><span class="p">(</span><span class="n">phone</span><span class="p">,</span> <span class="n">startB</span><span class="p">)</span>
+        <span class="n">startA</span> <span class="o">=</span> <span class="n">pronATmp</span><span class="o">.</span><span class="n">index</span><span class="p">(</span><span class="n">phone</span><span class="p">,</span> <span class="n">startA</span><span class="p">)</span>
+        <span class="n">startB</span> <span class="o">=</span> <span class="n">pronBTmp</span><span class="o">.</span><span class="n">index</span><span class="p">(</span><span class="n">phone</span><span class="p">,</span> <span class="n">startB</span><span class="p">)</span>
 
         <span class="n">sequenceIndexListA</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">startA</span><span class="p">)</span>
         <span class="n">sequenceIndexListB</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">startB</span><span class="p">)</span>
 
     <span class="c1"># An index on the tail of both will be used to create output strings</span>
     <span class="c1"># of the same length</span>
-    <span class="n">sequenceIndexListA</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">phoneListA</span><span class="p">))</span>
-    <span class="n">sequenceIndexListB</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">phoneListB</span><span class="p">))</span>
+    <span class="n">sequenceIndexListA</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">pronATmp</span><span class="p">))</span>
+    <span class="n">sequenceIndexListB</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">pronBTmp</span><span class="p">))</span>
 
     <span class="c1"># Fill in any blanks such that the sequential items have the same</span>
     <span class="c1"># index and the two strings are the same length</span>
@@ -926,16 +1010,16 @@
         <span class="n">indexB</span> <span class="o">=</span> <span class="n">sequenceIndexListB</span><span class="p">[</span><span class="n">i</span><span class="p">]</span>
         <span class="k">if</span> <span class="n">indexA</span> <span class="o">&lt;</span> <span class="n">indexB</span><span class="p">:</span>
             <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="n">indexB</span> <span class="o">-</span> <span class="n">indexA</span><span class="p">):</span>
-                <span class="n">phoneListA</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="n">indexA</span><span class="p">,</span> <span class="s2">&quot;&#39;&#39;&quot;</span><span class="p">)</span>
+                <span class="n">pronATmp</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="n">indexA</span><span class="p">,</span> <span class="s2">&quot;&#39;&#39;&quot;</span><span class="p">)</span>
             <span class="n">sequenceIndexListA</span> <span class="o">=</span> <span class="p">[</span><span class="n">val</span> <span class="o">+</span> <span class="n">indexB</span> <span class="o">-</span> <span class="n">indexA</span>
                                   <span class="k">for</span> <span class="n">val</span> <span class="ow">in</span> <span class="n">sequenceIndexListA</span><span class="p">]</span>
         <span class="k">elif</span> <span class="n">indexA</span> <span class="o">&gt;</span> <span class="n">indexB</span><span class="p">:</span>
             <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="n">indexA</span> <span class="o">-</span> <span class="n">indexB</span><span class="p">):</span>
-                <span class="n">phoneListB</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="n">indexB</span><span class="p">,</span> <span class="s2">&quot;&#39;&#39;&quot;</span><span class="p">)</span>
+                <span class="n">pronBTmp</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="n">indexB</span><span class="p">,</span> <span class="s2">&quot;&#39;&#39;&quot;</span><span class="p">)</span>
             <span class="n">sequenceIndexListB</span> <span class="o">=</span> <span class="p">[</span><span class="n">val</span> <span class="o">+</span> <span class="n">indexA</span> <span class="o">-</span> <span class="n">indexB</span>
                                   <span class="k">for</span> <span class="n">val</span> <span class="ow">in</span> <span class="n">sequenceIndexListB</span><span class="p">]</span>
 
-    <span class="k">return</span> <span class="n">phoneListA</span><span class="p">,</span> <span class="n">phoneListB</span>
+    <span class="k">return</span> <span class="n">pronATmp</span><span class="p">,</span> <span class="n">pronBTmp</span>
 </pre></div>
 
         </details>

--- a/examples/alignment_example.py
+++ b/examples/alignment_example.py
@@ -19,7 +19,7 @@ of emotion or inflection (e.g. read speech).
 
 from os.path import join
 
-from praatio import tgio
+from praatio import textgrid
 
 from pysle import isletool
 from pysle import praattools
@@ -36,7 +36,7 @@ wordTierName = "word"
 phoneListTierName = "phoneList"
 phoneTierName = "phone"
 
-tg = tgio.openTextgrid(inputFN)
+tg = textgrid.openTextgrid(inputFN, includeEmptyIntervals=False)
 
 for tierName in tg.tierNameList[:]:
     if tierName == utteranceTierName:
@@ -46,4 +46,4 @@ tg = praattools.naiveWordAlignment(tg, utteranceTierName, wordTierName,
                                    isleDict, phoneListTierName)
 tg = praattools.naivePhoneAlignment(tg, wordTierName, phoneTierName,
                                     isleDict)
-tg.save(outputFN)
+tg.save(outputFN, format="short_textgrid", includeBlankSpaces=True)

--- a/examples/syllabify_textgrid.py
+++ b/examples/syllabify_textgrid.py
@@ -8,20 +8,20 @@ praatio library.
 
 from os.path import join
 
-from praatio import tgio
+from praatio import textgrid
 from pysle import isletool
 from pysle import praattools
 
 root = join('.', 'files')
 isleDict = isletool.LexicalTool(join(root, "ISLEdict_sample.txt"))
 
-tg = tgio.openTextgrid(join(root, "pumpkins.TextGrid"))
+tg = textgrid.openTextgrid(join(root, "problematicdx.TextGrid"), includeEmptyIntervals=False)
 
 # Get the syllabification tiers and add it to the textgrid
 syllableTG = praattools.syllabifyTextgrid(isleDict, tg, "word", "phone",
-                                          skipLabelList=["", ])
+                                          skipLabelList=["", ], stressedSyllableDetectionErrors="WARN", syllabificationError="WARN")
 tg.addTier(syllableTG.tierDict["syllable"])
 tg.addTier(syllableTG.tierDict["tonicSyllable"])
 tg.addTier(syllableTG.tierDict["tonicVowel"])
 
-tg.save(join(root, "pumpkins_with_syllables.TextGrid"))
+tg.save(join(root, "problematicdx_with_syllables.TextGrid"), format="short_textgrid", includeBlankSpaces=True)

--- a/pysle/praattools.py
+++ b/pysle/praattools.py
@@ -19,7 +19,7 @@ class OptionalFeatureError(ImportError):
 
 
 try:
-    from praatio import tgio
+    from praatio import textgrid
     from praatio import praatio_scripts
 except ImportError:
     raise OptionalFeatureError()
@@ -128,10 +128,10 @@ def naiveWordAlignment(tg, utteranceTierName, wordTierName, isleDict,
         phoneEntryList.extend(subPhoneEntryList)
 
     # Replace or add the word tier
-    newWordTier = tgio.IntervalTier(wordTierName,
-                                    wordEntryList,
-                                    tg.minTimestamp,
-                                    tg.maxTimestamp)
+    newWordTier = textgrid.IntervalTier(wordTierName,
+                                        wordEntryList,
+                                        tg.minTimestamp,
+                                        tg.maxTimestamp)
     if wordTier is not None:
         tg.replaceTier(wordTierName, newWordTier)
     else:
@@ -141,10 +141,10 @@ def naiveWordAlignment(tg, utteranceTierName, wordTierName, isleDict,
     # Add the phone tier
     # This is mainly used as an annotation tier
     if phoneHelperTierName is not None and len(phoneEntryList) > 0:
-        newPhoneTier = tgio.IntervalTier(phoneHelperTierName,
-                                         phoneEntryList,
-                                         tg.minTimestamp,
-                                         tg.minTimestamp)
+        newPhoneTier = textgrid.IntervalTier(phoneHelperTierName,
+                                             phoneEntryList,
+                                             tg.minTimestamp,
+                                             tg.maxTimestamp)
         if phoneHelperTierName in tg.tierNameList:
             tg.replaceTier(phoneHelperTierName, newPhoneTier)
         else:
@@ -213,10 +213,10 @@ def naivePhoneAlignment(tg, wordTierName, phoneTierName, isleDict,
         phoneEntryList.extend(subPhoneEntryList)
 
     # Replace or add the phone tier
-    newPhoneTier = tgio.IntervalTier(phoneTierName,
-                                     phoneEntryList,
-                                     tg.minTimestamp,
-                                     tg.maxTimestamp)
+    newPhoneTier = textgrid.IntervalTier(phoneTierName,
+                                        phoneEntryList,
+                                        tg.minTimestamp,
+                                        tg.maxTimestamp)
     if phoneTier is not None:
         tg.replaceTier(phoneTierName, newPhoneTier)
     else:
@@ -337,14 +337,14 @@ def syllabifyTextgrid(isleDict, tg, wordTierName, phoneTierName,
                 tonicPEntryList.append((phoneStart, phoneEnd, 'T'))
 
     # Create a textgrid with the two syllable-level tiers
-    syllableTier = tgio.IntervalTier('syllable', syllableEntryList,
-                                     minT, maxT)
-    tonicSTier = tgio.IntervalTier('tonicSyllable', tonicSEntryList,
-                                   minT, maxT)
-    tonicPTier = tgio.IntervalTier('tonicVowel', tonicPEntryList,
-                                   minT, maxT)
+    syllableTier = textgrid.IntervalTier('syllable', syllableEntryList,
+                                         minT, maxT)
+    tonicSTier = textgrid.IntervalTier('tonicSyllable', tonicSEntryList,
+                                       minT, maxT)
+    tonicPTier = textgrid.IntervalTier('tonicVowel', tonicPEntryList,
+                                       minT, maxT)
 
-    syllableTG = tgio.Textgrid()
+    syllableTG = textgrid.Textgrid()
     syllableTG.addTier(syllableTier)
     syllableTG.addTier(tonicSTier)
     syllableTG.addTier(tonicPTier)

--- a/pysle/praattools.py
+++ b/pysle/praattools.py
@@ -329,7 +329,7 @@ def syllabifyTextgrid(isleDict, tg, wordTierName, phoneTierName,
                 try:
                     tmpStressJ = cvList.index('V')
                 except ValueError:
-                    for char in [u'r', u'n', u'l']:
+                    for char in [u'r', u'm', u'n', u'l']:
                         if char in cvList:
                             tmpStressJ = cvList.index(char)
                             break

--- a/pysle/praattools.py
+++ b/pysle/praattools.py
@@ -325,6 +325,7 @@ def syllabifyTextgrid(isleDict, tg, wordTierName, phoneTierName,
                 justPhones = [phone for _, _, phone in phoneList]
                 cvList = pronunciationtools.simplifyPronunciation(justPhones)
 
+                tmpStressJ = None
                 try:
                     tmpStressJ = cvList.index('V')
                 except ValueError:

--- a/pysle/pronunciationtools.py
+++ b/pysle/pronunciationtools.py
@@ -284,8 +284,8 @@ def alignPronunciations(phoneListA, phoneListB):
     '''
 
     # Remove any elements not in the other list (but maintain order)
-    pronATmp = phoneListA
-    pronBTmp = phoneListB
+    pronATmp = copy.deepcopy(phoneListA)
+    pronBTmp = copy.deepcopy(phoneListB)
 
     # Find the longest sequence
     sequence = _lcs(pronBTmp, pronATmp)
@@ -297,16 +297,16 @@ def alignPronunciations(phoneListA, phoneListB):
     sequenceIndexListA = []
     sequenceIndexListB = []
     for phone in sequence:
-        startA = phoneListA.index(phone, startA)
-        startB = phoneListB.index(phone, startB)
+        startA = pronATmp.index(phone, startA)
+        startB = pronBTmp.index(phone, startB)
 
         sequenceIndexListA.append(startA)
         sequenceIndexListB.append(startB)
 
     # An index on the tail of both will be used to create output strings
     # of the same length
-    sequenceIndexListA.append(len(phoneListA))
-    sequenceIndexListB.append(len(phoneListB))
+    sequenceIndexListA.append(len(pronATmp))
+    sequenceIndexListB.append(len(pronBTmp))
 
     # Fill in any blanks such that the sequential items have the same
     # index and the two strings are the same length
@@ -315,16 +315,16 @@ def alignPronunciations(phoneListA, phoneListB):
         indexB = sequenceIndexListB[i]
         if indexA < indexB:
             for _ in range(indexB - indexA):
-                phoneListA.insert(indexA, "''")
+                pronATmp.insert(indexA, "''")
             sequenceIndexListA = [val + indexB - indexA
                                   for val in sequenceIndexListA]
         elif indexA > indexB:
             for _ in range(indexA - indexB):
-                phoneListB.insert(indexB, "''")
+                pronBTmp.insert(indexB, "''")
             sequenceIndexListB = [val + indexA - indexB
                                   for val in sequenceIndexListB]
 
-    return phoneListA, phoneListB
+    return pronATmp, pronBTmp
 
 
 def findBestSyllabification(isleDict, wordText, phoneList):

--- a/pysle/pronunciationtools.py
+++ b/pysle/pronunciationtools.py
@@ -27,6 +27,18 @@ class TooManyVowelsInSyllable(Exception):
         return errStr % (syllableStr, syllableCVStr)
 
 
+class ImpossibleSyllabificationError(Exception):
+
+    def __init__(self, estimatedActualSyllabificationList, isleSyllabificationList):
+        self.estimatedList = estimatedActualSyllabificationList
+        self.isleSyllabificationList = isleSyllabificationList
+
+    def __str__(self):
+        return (f"Impossible syllabification; "
+            f"Estimated: {self.estimatedList}; "
+            f"ISLE's: {self.isleSyllabificationList}"
+            )
+
 class NumWordsMismatchError(Exception):
 
     def __init__(self, word, numMatches):
@@ -372,7 +384,10 @@ def _findBestSyllabification(inputIsleWordList, actualPronunciationList):
         stressedSyllableI = None
         stressedVowelI = None
     else:
-        stressedVowelI = _getSyllableNucleus(syllableList[stressedSyllableI])
+        try:
+            stressedVowelI = _getSyllableNucleus(syllableList[stressedSyllableI])
+        except TooManyVowelsInSyllable as err:
+            raise ImpossibleSyllabificationError(syllableList, alignedSyllables) from err
 
     # Count the index of the stressed phones, if the stress list has
     # become flattened (no syllable information)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     license="LICENSE",
     description="An interface to ISLEX, an IPA pronunciation dictionary "
     "for English with stress and syllable markings.",
-    install_requires=["praatio ~= 4.1"],
+    install_requires=["praatio >= 5.0"],
     long_description=io.open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 setup(
     name="pysle",
-    version="2.3.1",
+    version="3.0",
     author="Tim Mahrt",
     author_email="timmahrt@gmail.com",
     url="https://github.com/timmahrt/pysle",


### PR DESCRIPTION
This PR does the following:
- [x] fixes several important bugs related to syllable alignment
    - a variable set inside a loop was never properly initialized (if there is not stress specified by ISLE, a stressed syllable of the current word would be marked the same as the previous word)
    - a argument to a function was mutated inside of the function (if there were multiple entries for a word in ISLE, later entries would be penalized stronger compared with earlier entries)
- [x] adds more flexibility in error handling with praattools.syllabifyTextgrid
- [x] requires praatio 5.0 or greater
- [x] drops support for python 2.7 