### PR TITLE
Remove debug print statement

### DIFF
--- a/pysle/isletool.py
+++ b/pysle/isletool.py
@@ -47,7 +47,6 @@ class Isle:
         self.data: Dict[str, List[phonetics.Entry]] = {}
 
     def _load(self, islePath) -> Dict[str, List[str]]:
-        print("Text")
         return isle_io.readIsleDict(islePath)
 
     def _lazyLoad(self, word: str) -> List[phonetics.Entry]:


### PR DESCRIPTION
Hi, thanks for the very useful project! This PR is to fix a minor annoyance that I discovered while using pysle — whenever isletool is loaded it prints "Text" to standard out, so I was always wrapping my invocation like:

```python
with contextlib.redirect_stdout(None):
    isle = isletool.Isle()
```

But this print statement doesn't seem like it's doing anything useful so I figured it could be removed. 😉 